### PR TITLE
Simplify rotated 2x2 Toric code

### DIFF
--- a/qldpc/codes/common_test.py
+++ b/qldpc/codes/common_test.py
@@ -504,17 +504,13 @@ def test_css_ops() -> None:
     # successfully construct and reduce logical operators in a code with "over-complete" checks
     dist = 4
     code = codes.ToricCode(dist, rotated=True, field=2)
+    assert code.canonicalized.num_checks < code.num_checks
     assert code.get_code_params() == (dist**2, 2, dist)
     code.reduce_logical_ops()
     logical_ops_x = code.get_logical_ops(Pauli.X)
     logical_ops_z = code.get_logical_ops(Pauli.Z, symplectic=True)
     assert not np.any(np.count_nonzero(logical_ops_x.view(np.ndarray), axis=1) < dist)
     assert not np.any(np.count_nonzero(logical_ops_z.view(np.ndarray), axis=1) < dist)
-
-    # the 2x2 toric code has redundant stabilizers
-    code = codes.ToricCode(2)
-    assert code.num_checks == 4
-    assert code.canonicalized.num_checks == 2
 
 
 def test_distance_css() -> None:

--- a/qldpc/codes/quantum.py
+++ b/qldpc/codes/quantum.py
@@ -1399,6 +1399,13 @@ class ToricCode(CSSCode):
                 matrix_z = code_field(matrix_z)
                 matrix_z[:, self._default_conjugate] *= -1
 
+            if rows == cols == 2 and rotated:
+                # All Toric codes have redundant parity checks, but the case of the rotated 2x2
+                # Toric code is particularly egregious -- the two X/Z checks are *equal* -- so
+                # remove the extra checks in this case.
+                matrix_x = matrix_x[:-1]
+                matrix_z = matrix_z[:-1]
+
         else:
             # "original" toric code
             code_a = RingCode(rows, field)

--- a/qldpc/codes/quantum.py
+++ b/qldpc/codes/quantum.py
@@ -1401,8 +1401,8 @@ class ToricCode(CSSCode):
 
             if rows == cols == 2 and rotated:
                 # All Toric codes have redundant parity checks, but the case of the rotated 2x2
-                # Toric code is particularly egregious -- the two X/Z checks are *equal* -- so
-                # remove the extra checks in this case.
+                # Toric code is particularly egregious: the two X/Z checks are *equal*.  So remove
+                # the extra checks in this case.
                 matrix_x = matrix_x[:-1]
                 matrix_z = matrix_z[:-1]
 

--- a/qldpc/codes/quantum_test.py
+++ b/qldpc/codes/quantum_test.py
@@ -493,6 +493,10 @@ def test_toric_codes() -> None:
     with pytest.raises(ValueError, match="even side lengths"):
         codes.ToricCode(3, rotated=True)
 
+    # the rotated 2x2 Toric code is special -- we remove redundant checks
+    code = codes.ToricCode(2, rotated=True)
+    assert len(code.matrix_x) == len(code.matrix_z) == 1
+
     # rotated toric XZZX code
     rows, cols = 6, 4
     code = codes.ToricCode(rows, cols, rotated=True)


### PR DESCRIPTION
All Toric codes have redundant checks, but the case of the rotated 2x2 Toric code is particularly egregious -- some checks are *equal* to others -- so remove the redundant checks in this case.