### PR TITLE
Add missing arithmetic for protographs

### DIFF
--- a/qldpc/abstract.py
+++ b/qldpc/abstract.py
@@ -603,6 +603,28 @@ class Protograph(npt.NDArray[np.object_]):
         if isinstance(group, Group):
             self._group = group
 
+    def __array_ufunc__(
+        self,
+        ufunc: np.ufunc,
+        method: typing.Literal["__call__", "reduce", "reduceat", "accumulate", "outer", "at"],
+        *inputs: Protograph | npt.NDArray[np.object_],
+        **kwargs: object,
+    ) -> Protograph | npt.NDArray[np.object_] | None:
+        """Intercept array operations to ensure Protograph compatibility."""
+        groups = set()
+        if method == "__call__":
+            groups |= {x._group for x in inputs if isinstance(x, Protograph)}
+            if len(groups) > 1:
+                raise ValueError(
+                    "Cannot perform operations on Protographs with different base groups"
+                )
+        inputs = tuple(x.view(np.ndarray) if isinstance(x, Protograph) else x for x in inputs)
+        result = super().__array_ufunc__(ufunc, method, *inputs, **kwargs)
+        if isinstance(result, np.ndarray):
+            result = result.view(Protograph)
+            setattr(result, "_group", next(iter(groups), None))
+        return result
+
     @property
     def group(self) -> Group:
         """Base group of this protograph."""

--- a/qldpc/abstract.py
+++ b/qldpc/abstract.py
@@ -575,7 +575,7 @@ def _protograph_arithmetic(
     """Decorator to set the group of protographs when performing arithmetic."""
 
     @functools.wraps(method)
-    def wrapper(protograph, other):
+    def wrapper(protograph: Protograph, other: object) -> Protograph:
         if isinstance(other, Protograph) and not protograph.group == other.group:
             raise ValueError(
                 "Cannot perform arithmetic with protographs that have different base groups"

--- a/qldpc/abstract.py
+++ b/qldpc/abstract.py
@@ -648,6 +648,32 @@ class Protograph(npt.NDArray[np.object_]):
         vals = [elevate(value) for value in array.ravel()]
         return Protograph(np.array(vals).reshape(array.shape), group)
 
+    def __add__(self, other: object) -> Protograph:
+        if isinstance(other, Protograph) and not self._group == other._group:
+            raise ValueError("Cannot add protographs with different base groups")
+        protograph = super().__add__(other)
+        protograph._group = self._group
+        return protograph
+
+    def __sub__(self, other: object) -> Protograph:
+        if isinstance(other, Protograph) and not self._group == other._group:
+            raise ValueError("Cannot add protographs with different base groups")
+        protograph = super().__sub__(other)
+        protograph._group = self._group
+        return protograph
+
+    def __mul__(self, other: object) -> Protograph:
+        if isinstance(other, Protograph) and not self._group == other._group:
+            raise ValueError("Cannot multiply protographs with different base groups")
+        protograph = super().__mul__(other)
+        protograph._group = self._group
+        return protograph
+
+    def __rmul__(self, other: object) -> Protograph:
+        protograph = super().__rmul__(other)
+        protograph._group = self._group
+        return protograph
+
     def __matmul__(self, other: object) -> Protograph:
         if isinstance(other, Protograph) and not self._group == other._group:
             raise ValueError("Cannot multiply protographs with different base groups")

--- a/qldpc/abstract.py
+++ b/qldpc/abstract.py
@@ -597,7 +597,7 @@ class Protograph(npt.NDArray[np.object_]):
 
         return protograph
 
-    def __array_finalize__(self, obj: Protograph | npt.NDArray[np.object_] | None) -> None:
+    def __array_finalize__(self, obj: npt.NDArray[np.object_] | None) -> None:
         """Propagate metadata to newly constructed arrays."""
         group = getattr(obj, "_group", None)
         if isinstance(group, Group):
@@ -607,9 +607,9 @@ class Protograph(npt.NDArray[np.object_]):
         self,
         ufunc: np.ufunc,
         method: typing.Literal["__call__", "reduce", "reduceat", "accumulate", "outer", "at"],
-        *inputs: Protograph | npt.NDArray[np.object_],
+        *inputs: npt.NDArray[np.object_],
         **kwargs: object,
-    ) -> Protograph | npt.NDArray[np.object_] | None:
+    ) -> Protograph | None:
         """Intercept array operations to ensure Protograph compatibility."""
         groups = set()
         if method == "__call__":

--- a/qldpc/abstract.py
+++ b/qldpc/abstract.py
@@ -569,24 +569,6 @@ class Element:
 # protographs: Element-valued matrices
 
 
-def _protograph_arithmetic(
-    method: Callable[[Protograph, object], Protograph],
-) -> Callable[[Protograph, object], Protograph]:
-    """Decorator to set the group of protographs when performing arithmetic."""
-
-    @functools.wraps(method)
-    def wrapper(protograph: Protograph, other: object) -> Protograph:
-        if isinstance(other, Protograph) and not protograph.group == other.group:
-            raise ValueError(
-                "Cannot perform arithmetic with protographs that have different base groups"
-            )
-        new_protograph = method(protograph, other)
-        new_protograph._group = protograph._group
-        return new_protograph
-
-    return wrapper
-
-
 class Protograph(npt.NDArray[np.object_]):
     """Array whose entries are members of a group algebra over a finite field."""
 
@@ -614,6 +596,12 @@ class Protograph(npt.NDArray[np.object_]):
         protograph._group = group
 
         return protograph
+
+    def __array_finalize__(self, obj: Protograph | npt.NDArray[np.object_] | None) -> None:
+        """Propagate metadata to newly constructed arrays."""
+        group = getattr(obj, "_group", None)
+        if isinstance(group, Group):
+            self._group = group
 
     @property
     def group(self) -> Group:
@@ -665,39 +653,6 @@ class Protograph(npt.NDArray[np.object_]):
 
         vals = [elevate(value) for value in array.ravel()]
         return Protograph(np.array(vals).reshape(array.shape), group)
-
-    @_protograph_arithmetic
-    def __add__(self, other: object) -> Protograph:
-        return super().__add__(other)
-
-    def __radd__(self, other: object) -> Protograph:
-        raise ValueError("__radd__ not supported for protographs")
-        return NotImplemented
-
-    @_protograph_arithmetic
-    def __sub__(self, other: object) -> Protograph:
-        return super().__sub__(other)
-
-    @_protograph_arithmetic
-    def __mul__(self, other: object) -> Protograph:
-        return super().__mul__(other)
-
-    @_protograph_arithmetic
-    def __rmul__(self, other: object) -> Protograph:
-        return super().__rmul__(other)
-
-    def __truediv__(self, other: object) -> Protograph:
-        if not isinstance(other, (self.group.field, int)):
-            raise ValueError("Protographs can only be divided by members of their base field")
-        return self * int(self.group.field(other) ** -1)
-
-    def __floordiv__(self, other: object) -> Protograph:
-        raise ValueError("__floordiv__ not supported for protographs")
-        return NotImplemented
-
-    @_protograph_arithmetic
-    def __matmul__(self, other: object) -> Protograph:
-        return super().__matmul__(other)
 
 
 ################################################################################

--- a/qldpc/abstract_test.py
+++ b/qldpc/abstract_test.py
@@ -138,6 +138,9 @@ def test_protograph() -> None:
         abstract.Protograph([[abstract.Element(group) for group in groups]])
     with pytest.raises(ValueError, match="Cannot determine the underlying group"):
         abstract.Protograph([])
+    with pytest.raises(ValueError, match="different base groups"):
+        new_protograph = abstract.Protograph.build(abstract.CyclicGroup(1), [[1]])
+        protograph @ new_protograph
 
 
 def test_transpose() -> None:

--- a/qldpc/abstract_test.py
+++ b/qldpc/abstract_test.py
@@ -127,8 +127,32 @@ def test_protograph() -> None:
     protograph = abstract.TrivialGroup.to_protograph(matrix)
     assert protograph.group == abstract.TrivialGroup()
     assert protograph.field == abstract.TrivialGroup().field
-    assert np.array_equal(protograph.lift(), matrix)
+
+    # array arithmetic
+    assert not np.any((protograph + protograph).lift())
+    assert not np.any((protograph - protograph).lift())
+    assert not np.any((2 * protograph).lift())
+    assert not np.any((protograph * 2).lift())
+    assert np.array_equal((protograph / 1).lift(), protograph.lift())
+    assert np.array_equal((protograph * protograph).lift(), protograph.lift())
     assert np.array_equal((protograph @ protograph).lift(), protograph.lift() @ protograph.lift())
+
+    # arithmetic failures
+    new_protograph = abstract.Protograph.build(abstract.CyclicGroup(1), [[1]])
+    with pytest.raises(ValueError, match="different base groups"):
+        protograph + new_protograph
+    with pytest.raises(ValueError, match="different base groups"):
+        protograph - new_protograph
+    with pytest.raises(ValueError, match="different base groups"):
+        protograph * new_protograph
+    with pytest.raises(ValueError, match="different base groups"):
+        protograph @ new_protograph
+    with pytest.raises(ValueError, match="not supported"):
+        1 + protograph
+    with pytest.raises(ValueError, match="not supported"):
+        protograph // 1
+    with pytest.raises(ValueError, match="base field"):
+        protograph / 1.5
 
     # fail to construct a valid protograph
     with pytest.raises(ValueError, match="must be Element-valued"):
@@ -138,9 +162,6 @@ def test_protograph() -> None:
         abstract.Protograph([[abstract.Element(group) for group in groups]])
     with pytest.raises(ValueError, match="Cannot determine the underlying group"):
         abstract.Protograph([])
-    with pytest.raises(ValueError, match="different base groups"):
-        new_protograph = abstract.Protograph.build(abstract.CyclicGroup(1), [[1]])
-        protograph @ new_protograph
 
 
 def test_transpose() -> None:

--- a/qldpc/abstract_test.py
+++ b/qldpc/abstract_test.py
@@ -127,32 +127,8 @@ def test_protograph() -> None:
     protograph = abstract.TrivialGroup.to_protograph(matrix)
     assert protograph.group == abstract.TrivialGroup()
     assert protograph.field == abstract.TrivialGroup().field
-
-    # array arithmetic
-    assert not np.any((protograph + protograph).lift())
-    assert not np.any((protograph - protograph).lift())
-    assert not np.any((2 * protograph).lift())
-    assert not np.any((protograph * 2).lift())
-    assert np.array_equal((protograph / 1).lift(), protograph.lift())
-    assert np.array_equal((protograph * protograph).lift(), protograph.lift())
+    assert np.array_equal(protograph.lift(), matrix)
     assert np.array_equal((protograph @ protograph).lift(), protograph.lift() @ protograph.lift())
-
-    # arithmetic failures
-    new_protograph = abstract.Protograph.build(abstract.CyclicGroup(1), [[1]])
-    with pytest.raises(ValueError, match="different base groups"):
-        protograph + new_protograph
-    with pytest.raises(ValueError, match="different base groups"):
-        protograph - new_protograph
-    with pytest.raises(ValueError, match="different base groups"):
-        protograph * new_protograph
-    with pytest.raises(ValueError, match="different base groups"):
-        protograph @ new_protograph
-    with pytest.raises(ValueError, match="not supported"):
-        1 + protograph
-    with pytest.raises(ValueError, match="not supported"):
-        protograph // 1
-    with pytest.raises(ValueError, match="base field"):
-        protograph / 1.5
 
     # fail to construct a valid protograph
     with pytest.raises(ValueError, match="must be Element-valued"):


### PR DESCRIPTION
New strategy: intercept numpy methods `__array_finalize__` and `__array_ufunc__` to set `_group` as appropriate