### PR TITLE
Propagate Protograph _group attribute

### DIFF
--- a/qldpc/abstract_test.py
+++ b/qldpc/abstract_test.py
@@ -138,9 +138,12 @@ def test_protograph() -> None:
         abstract.Protograph([[abstract.Element(group) for group in groups]])
     with pytest.raises(ValueError, match="Cannot determine the underlying group"):
         abstract.Protograph([])
+
+    new_protograph = abstract.Protograph.build(abstract.CyclicGroup(1), [[1]])
     with pytest.raises(ValueError, match="different base groups"):
-        new_protograph = abstract.Protograph.build(abstract.CyclicGroup(1), [[1]])
         protograph @ new_protograph
+    with pytest.raises(ValueError, match="different base groups"):
+        np.kron(protograph, new_protograph)
 
 
 def test_transpose() -> None:

--- a/qldpc/abstract_test.py
+++ b/qldpc/abstract_test.py
@@ -129,6 +129,7 @@ def test_protograph() -> None:
     assert protograph.field == abstract.TrivialGroup().field
     assert np.array_equal(protograph.lift(), matrix)
     assert np.array_equal((protograph @ protograph).lift(), protograph.lift() @ protograph.lift())
+    assert isinstance(np.kron(protograph, protograph), abstract.Protograph)
 
     # fail to construct a valid protograph
     with pytest.raises(ValueError, match="must be Element-valued"):

--- a/qldpc/codes/quantum.py
+++ b/qldpc/codes/quantum.py
@@ -729,7 +729,11 @@ class HGPCode(CSSCode):
         self._default_conjugate = slice(self.sector_size[0, 0], None)
 
         CSSCode.__init__(
-            self, matrix_x.astype(int), matrix_z.astype(int), field, is_subsystem_code=False
+            self,
+            matrix_x.view(np.ndarray).astype(int),
+            matrix_z.view(np.ndarray).astype(int),
+            field,
+            is_subsystem_code=True,
         )
 
         if set_logicals:
@@ -997,6 +1001,8 @@ class LPCode(CSSCode):
 
         # identify X-sector and Z-sector parity checks
         matrix_x, matrix_z = HGPCode.get_matrix_product(protograph_a, protograph_b)
+        assert isinstance(matrix_x, abstract.Protograph)
+        assert isinstance(matrix_z, abstract.Protograph)
 
         # identify the number of qudits in each sector
         self.sector_size = protograph_a.group.lift_dim * np.outer(
@@ -1007,13 +1013,7 @@ class LPCode(CSSCode):
         # if Hadamard-transforming qudits, conjugate those in the (1, 1) sector by default
         self._default_conjugate = slice(self.sector_size[0, 0], None)
 
-        CSSCode.__init__(
-            self,
-            abstract.Protograph(matrix_x.astype(object)).lift(),
-            abstract.Protograph(matrix_z.astype(object)).lift(),
-            field,
-            is_subsystem_code=False,
-        )
+        CSSCode.__init__(self, matrix_x.lift(), matrix_z.lift(), field, is_subsystem_code=False)
 
 
 class SLPCode(CSSCode):
@@ -1042,14 +1042,10 @@ class SLPCode(CSSCode):
 
         # identify X-sector and Z-sector parity checks
         matrix_x, matrix_z = SHPCode.get_matrix_product(protograph_a, protograph_b)
+        assert isinstance(matrix_x, abstract.Protograph)
+        assert isinstance(matrix_z, abstract.Protograph)
 
-        CSSCode.__init__(
-            self,
-            abstract.Protograph(matrix_x.astype(object)).lift(),
-            abstract.Protograph(matrix_z.astype(object)).lift(),
-            field,
-            is_subsystem_code=True,
-        )
+        CSSCode.__init__(self, matrix_x.lift(), matrix_z.lift(), field, is_subsystem_code=True)
 
 
 ################################################################################


### PR DESCRIPTION
This attribute was previously unset when using operations like `np.block` and `np.kron`.  That is fixed by adding a `Protograph.__array_function__` method.