### PR TITLE
Find the null space of `Protograph`s

### DIFF
--- a/qldpc/abstract.py
+++ b/qldpc/abstract.py
@@ -695,20 +695,14 @@ class Protograph(npt.NDArray[np.object_]):
     def lift(self) -> galois.FieldArray:
         """Block matrix obtained by lifting each entry of the protograph."""
         assert self.ndim == 2
-        vals = [val.lift() for val in self.ravel()]
-        tensor = np.transpose(np.reshape(vals, self.shape + vals[0].shape), [0, 2, 1, 3])
-        rows = tensor.shape[0] * tensor.shape[1]
-        cols = tensor.shape[2] * tensor.shape[3]
-        return self.field(tensor.reshape(rows, cols))
+        blocks = [[val.lift() for val in row] for row in self]
+        return self.field(np.block(blocks))
 
     def regular_lift(self) -> galois.FieldArray:
         """Block matrix obtained by a regular lift of ach entry of the protograph."""
         assert self.ndim == 2
-        vals = [val.regular_lift() for val in self.ravel()]
-        tensor = np.transpose(np.reshape(vals, self.shape + vals[0].shape), [0, 2, 1, 3])
-        rows = tensor.shape[0] * tensor.shape[1]
-        cols = tensor.shape[2] * tensor.shape[3]
-        return self.field(tensor.reshape(rows, cols))
+        blocks = [[val.regular_lift() for val in row] for row in self]
+        return self.field(np.block(blocks))
 
     @property
     def T(self) -> Protograph:

--- a/qldpc/abstract_test.py
+++ b/qldpc/abstract_test.py
@@ -92,22 +92,6 @@ def assert_valid_lift(group: abstract.Group) -> None:
         )
 
 
-@pytest.mark.parametrize("group", [abstract.DihedralGroup(3), abstract.AbelianGroup(2, 3, field=4)])
-def test_regular_rep(group: abstract.Group) -> None:
-    """The regular representation enables straightforward linear algebra over group algebras."""
-    dense_vector = group.field.Random(4 * group.order)
-    dense_array = group.field.Random((3, 4, group.order))
-
-    vector = abstract.Protograph.from_dense_vector(group, dense_vector)
-    matrix = abstract.Protograph.from_dense_array(group, dense_array)
-    assert np.array_equal(dense_vector, abstract.Protograph.to_dense_vector(vector))
-    assert np.array_equal(dense_array, abstract.Protograph.to_dense_array(matrix))
-    assert np.array_equal(
-        (matrix @ vector).to_dense_vector(),
-        matrix.lift() @ vector.to_dense_vector(),
-    )
-
-
 def test_group_product() -> None:
     """Direct product of groups."""
     cycle = abstract.CyclicGroup(2)
@@ -123,6 +107,20 @@ def test_group_product() -> None:
     assert group.generators == [shift @ identity, identity @ shift]
     assert np.array_equal(table, group.table)
     assert np.array_equal(table, abstract.Group.from_table(table).table)
+
+
+def test_random_symmetric_subset() -> None:
+    """Cover Group.random_symmetric_subset."""
+    group = abstract.CyclicGroup(2) * abstract.CyclicGroup(3)
+    for seed in [0, 1]:
+        subset = group.random_symmetric_subset(size=2, seed=seed)
+        assert subset == {~member for member in subset}
+
+    subset = group.random_symmetric_subset(size=1, exclude_identity=False, seed=0)
+    assert subset == {group.identity}
+
+    with pytest.raises(ValueError, match="must have a size between"):
+        group.random_symmetric_subset(size=0)
 
 
 def test_algebra() -> None:
@@ -177,18 +175,23 @@ def test_transpose() -> None:
     assert np.array_equal(protograph.T.T, protograph)
 
 
-def test_random_symmetric_subset() -> None:
-    """Cover Group.random_symmetric_subset."""
-    group = abstract.CyclicGroup(2) * abstract.CyclicGroup(3)
-    for seed in [0, 1]:
-        subset = group.random_symmetric_subset(size=2, seed=seed)
-        assert subset == {~member for member in subset}
+@pytest.mark.parametrize("group", [abstract.DihedralGroup(3), abstract.AbelianGroup(2, 3, field=4)])
+def test_regular_rep(group: abstract.Group) -> None:
+    """The regular representation enables straightforward linear algebra over group algebras."""
+    dense_vector = group.field.Random(4 * group.order)
+    dense_array = group.field.Random((3, 4, group.order))
 
-    subset = group.random_symmetric_subset(size=1, exclude_identity=False, seed=0)
-    assert subset == {group.identity}
+    vector = abstract.Protograph.from_dense_vector(group, dense_vector)
+    matrix = abstract.Protograph.from_dense_array(group, dense_array)
+    assert np.array_equal(dense_vector, abstract.Protograph.to_dense_vector(vector))
+    assert np.array_equal(dense_array, abstract.Protograph.to_dense_array(matrix))
+    assert np.array_equal(
+        (matrix @ vector).to_dense_vector(),
+        matrix.lift() @ vector.to_dense_vector(),
+    )
 
-    with pytest.raises(ValueError, match="must have a size between"):
-        group.random_symmetric_subset(size=0)
+    assert not np.any(matrix @ matrix.null_space().T)
+    assert matrix.null_space(reduce=True) is NotImplemented
 
 
 @pytest.mark.parametrize("dimension,field,linear_rep", [(2, 4, True), (2, 2, False)])


### PR DESCRIPTION
The null space of a protograph `matrix` satisfies
```python
assert not np.any(matrix @ matrix.null_space().T)
assert not np.any(matrix.regular_lift() @ matrix.null_space().regular_lift().T)
assert not np.any(matrix.regular_lift() @ matrix.regular_lift().null_space().T)
```

At the moment, the null space is over-complete.  A later PR will add a method to reduce the null space to a minimal basis.