### PR TITLE
Rename `Element -> RingMember` and `Protograph -> RingArray`

### DIFF
--- a/qldpc/abstract.py
+++ b/qldpc/abstract.py
@@ -36,6 +36,7 @@ import functools
 import itertools
 import math
 import operator
+import types
 import typing
 import warnings
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
@@ -614,7 +615,7 @@ class Element(RingMember):
 
     def __getattribute__(self, name: str) -> Callable[..., typing.Any]:
         attribute = super().__getattribute__(name)
-        if callable(attribute):
+        if isinstance(attribute, types.MethodType):
 
             def wrapper(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
                 warnings.warn(
@@ -805,7 +806,7 @@ class Protograph(RingArray):
 
     def __getattribute__(self, name: str) -> Callable[..., typing.Any]:
         attribute = super().__getattribute__(name)
-        if callable(attribute):
+        if isinstance(attribute, types.MethodType):
 
             def wrapper(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
                 warnings.warn(

--- a/qldpc/abstract.py
+++ b/qldpc/abstract.py
@@ -610,7 +610,7 @@ class RingMember:
         return vector
 
 
-class Element(RingMember):
+class Element(RingMember):  # pragma: no cover
     """Deprecated alias for RingMember."""
 
     def __getattribute__(self, name: str) -> Callable[..., typing.Any]:
@@ -801,7 +801,7 @@ class RingArray(npt.NDArray[np.object_]):
         return RingArray(null_space)
 
 
-class Protograph(RingArray):
+class Protograph(RingArray):  # pragma: no cover
     """Deprecated alias for RingArray."""
 
     def __getattribute__(self, name: str) -> Callable[..., typing.Any]:

--- a/qldpc/abstract.py
+++ b/qldpc/abstract.py
@@ -568,7 +568,7 @@ class RingMember:
         )
 
     def regular_lift(self) -> galois.FieldArray:
-        """Lift this element using the regular group representation."""
+        """Lift this element using the regular representation of its base group."""
         return sum(
             (val * self.group.regular_lift(member) for val, member in self if val),
             start=self.field.Zeros((self.group.order,) * 2),
@@ -612,11 +612,18 @@ class RingMember:
 class Element(RingMember):
     """Deprecated alias for RingMember."""
 
-    def __init__(
-        self, group: Group, *terms: GroupMember | tuple[int | galois.FieldArray, GroupMember]
-    ) -> None:
-        warnings.warn("qldpc.abstract.Element is deprecated; use qldpc.abstract.RingMember instead")
-        super().__init__(group, *terms)
+    def __getattribute__(self, name: str) -> Callable[..., typing.Any]:
+        attribute = super().__getattribute__(name)
+        if callable(attribute):
+
+            def wrapper(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
+                warnings.warn(
+                    "qldpc.abstract.Element is deprecated; use qldpc.abstract.RingMember instead"
+                )
+                return attribute(*args, **kwargs)
+
+            return wrapper
+        return attribute
 
 
 ################################################################################
@@ -796,13 +803,18 @@ class RingArray(npt.NDArray[np.object_]):
 class Protograph(RingArray):
     """Deprecated alias for RingArray."""
 
-    def __new__(
-        cls, data: npt.NDArray[np.object_] | Sequence[Sequence[object]], group: Group | None = None
-    ) -> RingArray:
-        warnings.warn(
-            "qldpc.abstract.RingArray is deprecated; use qldpc.abstract.RingArray instead"
-        )
-        return RingArray(data, group)
+    def __getattribute__(self, name: str) -> Callable[..., typing.Any]:
+        attribute = super().__getattribute__(name)
+        if callable(attribute):
+
+            def wrapper(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
+                warnings.warn(
+                    "qldpc.abstract.Protograph is deprecated; use qldpc.abstract.RingArray instead"
+                )
+                return attribute(*args, **kwargs)
+
+            return wrapper
+        return attribute
 
 
 ################################################################################

--- a/qldpc/abstract_test.py
+++ b/qldpc/abstract_test.py
@@ -126,8 +126,8 @@ def test_random_symmetric_subset() -> None:
 def test_algebra() -> None:
     """Construct elements of a group algebra."""
     group = abstract.TrivialGroup(field=3)
-    zero = abstract.Element(group)
-    one = abstract.Element(group).one()
+    zero = abstract.RingMember(group)
+    one = abstract.RingMember(group).one()
     assert bool(one) and not bool(zero)
     assert zero.group == group
     assert one + 2 == group.identity + 2 * one == -one + 1 == one - 1 == zero
@@ -150,11 +150,11 @@ def test_ring_array() -> None:
     assert isinstance(np.kron(matrix, matrix), abstract.RingArray)
 
     # fail to construct a valid ring array
-    with pytest.raises(ValueError, match="must be Element-valued"):
+    with pytest.raises(ValueError, match="must be RingMember-valued"):
         abstract.RingArray([[0]])
     with pytest.raises(ValueError, match="Inconsistent base groups"):
         groups = [abstract.TrivialGroup(), abstract.CyclicGroup(1)]
-        abstract.RingArray([[abstract.Element(group) for group in groups]])
+        abstract.RingArray([[abstract.RingMember(group) for group in groups]])
     with pytest.raises(ValueError, match="Cannot determine the underlying group"):
         abstract.RingArray([])
 
@@ -169,11 +169,11 @@ def test_transpose() -> None:
     """Transpose various objects."""
     group = abstract.CyclicGroup(4)
     for member in group.generate():
-        element = abstract.Element(group, member)
+        element = abstract.RingMember(group, member)
         assert element.T.T == element
 
     x0, x1, x2, x3 = group.generate()
-    matrix = abstract.RingArray.build(group, [[x0, 0, x1], [x2, 0, abstract.Element(group, x3)]])
+    matrix = abstract.RingArray.build(group, [[x0, 0, x1], [x2, 0, abstract.RingMember(group, x3)]])
     assert np.array_equal(matrix.T.T, matrix)
 
 

--- a/qldpc/codes/quantum_test.py
+++ b/qldpc/codes/quantum_test.py
@@ -265,19 +265,19 @@ def test_trivial_lift(
     code_b = codes.ClassicalCode.random(*bits_checks_b, field=field, seed=np.random.randint(2**32))
     code_HGP = codes.HGPCode(code_a, code_b, field)
 
-    protograph_a = abstract.TrivialGroup.to_protograph(code_a.matrix, field)
-    protograph_b = abstract.TrivialGroup.to_protograph(code_b.matrix, field)
-    code_LP = codes.LPCode(protograph_a, protograph_b)
+    matrix_a = abstract.TrivialGroup.to_ring_array(code_a.matrix, field)
+    matrix_b = abstract.TrivialGroup.to_ring_array(code_b.matrix, field)
+    code_LP = codes.LPCode(matrix_a, matrix_b)
 
     assert np.array_equal(code_HGP.matrix_x, code_LP.matrix_x)
     assert np.array_equal(code_HGP.matrix_z, code_LP.matrix_z)
     assert nx.utils.graphs_equal(code_HGP.graph, code_LP.graph)
     assert np.array_equal(code_HGP.sector_size, code_LP.sector_size)
 
-    chain = ChainComplex.tensor_product(protograph_a, protograph_b.T)
+    chain = ChainComplex.tensor_product(matrix_a, matrix_b.T)
     matrix_x, matrix_z = chain.op(1), chain.op(2).T
-    assert isinstance(matrix_x, abstract.Protograph)
-    assert isinstance(matrix_z, abstract.Protograph)
+    assert isinstance(matrix_x, abstract.RingArray)
+    assert isinstance(matrix_z, abstract.RingArray)
     assert np.array_equal(matrix_x.lift(), code_HGP.matrix_x)
     assert np.array_equal(matrix_z.lift(), code_HGP.matrix_z)
 
@@ -285,12 +285,12 @@ def test_trivial_lift(
 def test_lift() -> None:
     """Verify lifting in Eqs. (8) and (10) of arXiv:2202.01702v3."""
     group = abstract.CyclicGroup(3)
-    zero = abstract.Element(group)
-    x0, x1, x2 = [abstract.Element(group, member) for member in group.generate()]
+    zero = abstract.RingMember(group)
+    x0, x1, x2 = [abstract.RingMember(group, member) for member in group.generate()]
     base_matrix = [[x1 + x2, x0, zero], [zero, x0 + x1, x1]]
 
-    protograph = abstract.Protograph(base_matrix)
-    matrix = [
+    ring_matrix = abstract.RingArray(base_matrix)
+    lifted_matrix = [
         [0, 1, 1, 1, 0, 0, 0, 0, 0],
         [1, 0, 1, 0, 1, 0, 0, 0, 0],
         [1, 1, 0, 0, 0, 1, 0, 0, 0],
@@ -298,11 +298,11 @@ def test_lift() -> None:
         [0, 0, 0, 1, 1, 0, 1, 0, 0],
         [0, 0, 0, 0, 1, 1, 0, 1, 0],
     ]
-    assert np.array_equal(protograph.lift(), matrix)
+    assert np.array_equal(ring_matrix.lift(), lifted_matrix)
 
     # check that the lifted product code is indeed smaller than the HGP code!
-    code_HP = codes.HGPCode(matrix)
-    code_LP = codes.LPCode(protograph)
+    code_HP = codes.HGPCode(lifted_matrix)
+    code_LP = codes.LPCode(ring_matrix)
     assert code_HP.num_qudits > code_LP.num_qudits
     assert code_HP.num_checks > code_LP.num_checks
 
@@ -333,8 +333,8 @@ def test_twisted_XZZX(width: int = 3) -> None:
 
     # construct lifted product code
     group = abstract.CyclicGroup(num_qudits // 2)
-    unit = abstract.Element(group).one()
-    shift = abstract.Element(group, group.generators[0])
+    unit = abstract.RingMember(group).one()
+    shift = abstract.RingMember(group, group.generators[0])
     element_a = unit - shift**width
     element_b = unit - shift
     code = codes.LPCode([[element_a]], [[element_b]])
@@ -342,32 +342,33 @@ def test_twisted_XZZX(width: int = 3) -> None:
     assert np.array_equal(matrix, code.conjugated(qudits_to_conjugate).matrix)
 
     # same construction with a chain complex
-    protograph_a = abstract.Protograph([[element_a]])
-    protograph_b = abstract.Protograph([[element_b]])
-    chain = ChainComplex.tensor_product(protograph_a, protograph_b.T)
+    matrix_a = abstract.RingArray([[element_a]])
+    matrix_b = abstract.RingArray([[element_b]])
+    chain = ChainComplex.tensor_product(matrix_a, matrix_b.T)
     matrix_x, matrix_z = chain.op(1), chain.op(2).T
-    assert isinstance(matrix_x, abstract.Protograph)
-    assert isinstance(matrix_z, abstract.Protograph)
+    assert isinstance(matrix_x, abstract.RingArray)
+    assert isinstance(matrix_z, abstract.RingArray)
     code = codes.CSSCode(matrix_x.lift(), matrix_z.lift()).conjugated(qudits_to_conjugate)
     assert np.array_equal(matrix, code.matrix)
 
 
 def test_lifted_product_codes() -> None:
     """Lifted product codes in Eq. (5) of arXiv:2308.08648."""
-    for lift_dim, matrix in [
+    for lift_dim, exponents in [
         (16, [[0, 0, 0, 0, 0], [0, 2, 4, 7, 11], [0, 3, 10, 14, 15]]),
         (21, [[0, 0, 0, 0, 0], [0, 4, 5, 7, 17], [0, 14, 18, 12, 11]]),
     ]:
         group = abstract.CyclicGroup(lift_dim)
         xx = group.generators[0]
-        proto_matrix = [[abstract.Element(group, xx**power) for power in row] for row in matrix]
-        protograph = abstract.Protograph(proto_matrix)
-        code = codes.LPCode(protograph)
+        matrix = abstract.RingArray.build(
+            group, [[xx**power for power in row] for row in exponents]
+        )
+        code = codes.LPCode(matrix)
         rate = code.dimension / code.num_qudits
         assert rate >= 2 / 17
 
         # the subsystem version of this code has a highe encoding rate
-        subsystem_code = codes.SLPCode(protograph)
+        subsystem_code = codes.SLPCode(matrix)
         subsystem_rate = subsystem_code.dimension / subsystem_code.num_qudits
         assert subsystem_rate > rate
 

--- a/qldpc/objects.py
+++ b/qldpc/objects.py
@@ -371,21 +371,21 @@ class ChainComplex:
     """
 
     _field: type[galois.FieldArray]
-    _ops: tuple[npt.NDArray[np.int_] | abstract.Protograph, ...]
+    _ops: tuple[npt.NDArray[np.int_] | abstract.RingArray, ...]
 
     # if boundary operators are defined over a group algebra, keep track of their base group
     _group: abstract.Group | None
 
     def __init__(
         self,
-        *ops: npt.NDArray[np.int_] | abstract.Protograph,
+        *ops: npt.NDArray[np.int_] | abstract.RingArray,
         field: int | None = None,
         skip_validation: bool = False,
     ) -> None:
         # check that either all or none of the operators are defined over a group algebra
         if not (
-            all(isinstance(op, abstract.Protograph) for op in ops)
-            or not any(isinstance(op, abstract.Protograph) for op in ops)
+            all(isinstance(op, abstract.RingArray) for op in ops)
+            or not any(isinstance(op, abstract.RingArray) for op in ops)
         ):
             raise ValueError("Invalid or inconsistent operator types provided for a ChainComplex")
 
@@ -393,7 +393,7 @@ class ChainComplex:
         fields = set([galois.GF(field)]) if field is not None else set()
         groups = set()
         for op in ops:
-            if isinstance(op, abstract.Protograph):
+            if isinstance(op, abstract.RingArray):
                 fields.add(op.field)
                 groups.add(op.group)
             elif isinstance(op, galois.FieldArray):
@@ -437,7 +437,7 @@ class ChainComplex:
         return len(self.ops)
 
     @property
-    def ops(self) -> tuple[npt.NDArray[np.int_] | abstract.Protograph, ...]:
+    def ops(self) -> tuple[npt.NDArray[np.int_] | abstract.RingArray, ...]:
         """The boundary operators of this chain complex."""
         return self._ops
 
@@ -451,7 +451,7 @@ class ChainComplex:
         dual_ops = [op.T for op in self.ops[::-1]]
         return ChainComplex(*dual_ops, skip_validation=True)
 
-    def op(self, degree: int) -> npt.NDArray[np.int_] | abstract.Protograph:
+    def op(self, degree: int) -> npt.NDArray[np.int_] | abstract.RingArray:
         """The boundary operator of this chain complex that acts on the module of a given degree."""
         assert 0 <= degree <= self.num_links + 1
         if degree == 0:
@@ -462,8 +462,8 @@ class ChainComplex:
 
     @staticmethod
     def tensor_product(  # noqa: C901 ignore complexity check
-        chain_a: ChainComplex | npt.NDArray[np.int_] | galois.FieldArray | abstract.Protograph,
-        chain_b: ChainComplex | npt.NDArray[np.int_] | galois.FieldArray | abstract.Protograph,
+        chain_a: ChainComplex | npt.NDArray[np.int_] | galois.FieldArray | abstract.RingArray,
+        chain_b: ChainComplex | npt.NDArray[np.int_] | galois.FieldArray | abstract.RingArray,
         field: int | None = None,
     ) -> ChainComplex:
         """Tensor product of two chain complexes.
@@ -547,5 +547,5 @@ class ChainComplex:
         if chain_a.group is None:
             ops = [chain_field(op) for op in ops]
         else:
-            ops = [abstract.Protograph(op) for op in ops]
+            ops = [abstract.RingArray(op) for op in ops]
         return ChainComplex(*ops, skip_validation=True)

--- a/qldpc/objects_test.py
+++ b/qldpc/objects_test.py
@@ -119,8 +119,8 @@ def test_chain_complex(field: int = 3) -> None:
     """Chain complex construction and errors."""
 
     # tensor product of one-complexes
-    mat = np.random.randint(field, size=(2, 3))
-    two_chain = objects.ChainComplex.tensor_product(mat, mat, field)
+    matrix = np.random.randint(field, size=(2, 3))
+    two_chain = objects.ChainComplex.tensor_product(matrix, matrix, field)
     assert not np.any(two_chain.op(0))
     assert not np.any(two_chain.op(two_chain.num_links + 1))
 
@@ -129,17 +129,17 @@ def test_chain_complex(field: int = 3) -> None:
     four_chain._validate_ops()
 
     # tensor product of one-complexes over a group algebra
-    protograph = abstract.Protograph.build(abstract.TrivialGroup(field), mat)
-    two_chain = objects.ChainComplex.tensor_product(protograph, protograph, field)
+    ring_matrix = abstract.RingArray.build(abstract.TrivialGroup(field), matrix)
+    two_chain = objects.ChainComplex.tensor_product(ring_matrix, ring_matrix, field)
     assert not np.any(two_chain.op(0))
     assert not np.any(two_chain.op(two_chain.num_links + 1))
 
     # invalid chain complex constructions
     with pytest.raises(ValueError, match="inconsistent operator types"):
-        objects.ChainComplex(mat, abstract.TrivialGroup.to_protograph([[0]]))
+        objects.ChainComplex(matrix, abstract.TrivialGroup.to_ring_array([[0]]))
     with pytest.raises(ValueError, match="Inconsistent base fields"):
-        objects.ChainComplex(galois.GF(field)(mat), field=field**2)
+        objects.ChainComplex(galois.GF(field)(matrix), field=field**2)
     with pytest.raises(ValueError, match="boundary operators .* must compose to zero"):
-        objects.ChainComplex(mat, mat, field=field)
+        objects.ChainComplex(matrix, matrix, field=field)
     with pytest.raises(ValueError, match="different base fields"):
-        objects.ChainComplex.tensor_product(galois.GF(field)(mat), galois.GF(field**2)(mat))
+        objects.ChainComplex.tensor_product(galois.GF(field)(matrix), galois.GF(field**2)(matrix))


### PR DESCRIPTION
Make `abstract.Element` and `abstract.Protograph` subclass accordingly and raise deprecation warnings.