### PR TITLE
Update `checks/` to support `checks-superstaq>=0.5.45`

### DIFF
--- a/checks/all_.py
+++ b/checks/all_.py
@@ -4,5 +4,5 @@ import sys
 import checks_superstaq
 
 if __name__ == "__main__":
-    skip_and_ruff = ["--skip", "configs", "requirements", "build_docs", "--ruff"]
-    exit(checks_superstaq.all_.run(*skip_and_ruff, *sys.argv[1:]))
+    skip_files = ["--skip", "configs", "requirements", "build_docs"]
+    exit(checks_superstaq.all_.run(*skip_files, *sys.argv[1:]))

--- a/checks/format_.py
+++ b/checks/format_.py
@@ -4,4 +4,4 @@ import sys
 import checks_superstaq
 
 if __name__ == "__main__":
-    exit(checks_superstaq.ruff_format_.run(*sys.argv[1:]))
+    exit(checks_superstaq.format_.run(*sys.argv[1:]))

--- a/checks/lint_.py
+++ b/checks/lint_.py
@@ -4,4 +4,4 @@ import sys
 import checks_superstaq
 
 if __name__ == "__main__":
-    exit(checks_superstaq.ruff_lint_.run(*sys.argv[1:]))
+    exit(checks_superstaq.lint_.run(*sys.argv[1:]))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,9 @@ scipy = ">=1.14.1"
 stim = ">=1.14.0"
 sympy = ">=1.12"
 
-checks-superstaq = { version = ">=0.5.34", optional = true }
+checks-superstaq = { version = ">=0.5.45", optional = true }
 gurobipy = { version = ">=10.0.0", optional = true }
-poetry  = { version = ">=2.1.3", optional = true }
+poetry = { version = ">=2.1.3", optional = true }
 
 [tool.poetry.extras]
 dev = ["checks-superstaq", "poetry"]


### PR DESCRIPTION
With the resolution of https://github.com/Infleqtion/client-superstaq/issues/1195, `checks-superstaq==0.5.45` contains some changes to make `ruff` the default formatter and linter for `checks-superstaq`. In doing so, `ruff_format_.py` is now `format_.py` and `ruff_lint_.py` -> `lint_.py`. 

This PR makes the corresponding changes for `qLDPC`.