### PR TITLE
Swap "inner" and "outer" naming conventions for concatenated codes

### DIFF
--- a/qldpc/codes/common_test.py
+++ b/qldpc/codes/common_test.py
@@ -429,12 +429,12 @@ def test_qudit_concatenation() -> None:
     """Concatenate qudit codes."""
     code_5q = codes.FiveQubitCode()
 
-    # determine the number of copies of the inner code automatically
+    # determine the number of copies of the outer code automatically
     code = codes.QuditCode.concatenate(code_5q, code_5q)
-    assert len(code) == 5 * len(code_5q)
+    assert len(code) == len(code_5q) ** 2
     assert code.dimension == code_5q.dimension
 
-    # determine the number of copies of the inner and outer codes from wiring data
+    # determine the number of copies of the outer and inner codes from wiring data
     wiring = [0, 2, 4, 6, 8, 1, 3, 5, 7, 9]
     code = codes.QuditCode.concatenate(code_5q, code_5q, wiring)
     assert len(code) == 10 * len(code_5q)
@@ -550,12 +550,12 @@ def test_css_concatenation() -> None:
     """Concatenate CSS codes."""
     code_c4 = codes.ToricCode(2)
 
-    # determine the number of copies of the inner code automatically
+    # determine the number of copies of the outer code automatically
     code = codes.CSSCode.concatenate(code_c4, code_c4)
     assert len(code) == len(code_c4) ** 2
     assert code.dimension == code_c4.dimension**2
 
-    # determine the number of copies of the inner and outer codes from wiring data
+    # determine the number of copies of the outer and inner codes from wiring data
     wiring = [0, 2, 4, 6, 1, 3, 5, 7]
     code = codes.CSSCode.concatenate(code_c4, code_c4, wiring)
     assert len(code) == 4 * len(code_c4)


### PR DESCRIPTION
... to make the naming consistent with https://errorcorrectionzoo.org/c/quantum_concatenated and https://errorcorrectionzoo.org/list/quantum_concatenated.

After this PR, the "outer" code is the one that acts on physical qudits, and the logical qudits of the "outer" code are used as the physical qudits of the "inner" code.