### PR TITLE
Fix unpacking issue for python3.10

### DIFF
--- a/qldpc/codes/distance_test.py
+++ b/qldpc/codes/distance_test.py
@@ -216,9 +216,9 @@ def test_rows_to_ints(dtype: npt.DTypeLike) -> None:
 
     for indices in np.ndindex(ints.shape):
         i = indices[-1] * nbits
-        packed_bits = bits[*indices[:-1]][i : i + nbits]
+        packed_bits = bits[indices[:-1]][i : i + nbits]
         bitstr = "".join(map(str, packed_bits))
-        assert np.binary_repr(ints[*indices], len(bitstr)) == bitstr
+        assert np.binary_repr(ints[indices], len(bitstr)) == bitstr
 
     # Pack array with more dimensions
     bits = bits.reshape(5, 1, 2, -1)


### PR DESCRIPTION
When using python 3.10.12 in fresh environment on wsl ubuntu 22.04, tests will fail with this error:

    File "/mnt/c/Users/Ryan/Desktop/qLPDC_PR/qLDPC/qldpc/codes/distance_test.py", line 219
      packed_bits = bits[*indices[:-1]][i : i + nbits]
                         ^
    SyntaxError: invalid syntax

It seems being able to unpack a tuple in an index operator was established in[ this PEP](https://peps.python.org/pep-0646/
), but is only valid for python3.11 onwards. 

This commit fixes this issue by removing unpacking operator- numpy [recognizes](https://numpy.org/devdocs/user/basics.indexing.html) and unpacks tuples when indexing