### PR TITLE
Rename `QuditCode.get_dual_subsystem_code` to `QuditCode.dual`

### DIFF
--- a/qldpc/codes/common.py
+++ b/qldpc/codes/common.py
@@ -1535,6 +1535,10 @@ class QuditCode(AbstractCode):
             code._gauge_ops = transform_ops(self.get_gauge_ops())
         return code
 
+    def conjugate(self) -> QuditCode:
+        """The same code with all X-type and Z-type operators swapped."""
+        return self.conjugated()
+
     def deformed(
         self, circuit: str | stim.Circuit, *, preserve_logicals: bool = False
     ) -> QuditCode:
@@ -2619,6 +2623,23 @@ class CSSCode(QuditCode):
             qudits: The qudits to transform, or None for all qudits.  Default: None.
         """
         return super().conjugated(qudits).maybe_to_css()
+
+    def conjugate(self) -> CSSCode:
+        """The same code with all X-type and Z-type operators swapped."""
+        code = CSSCode(self.code_z, self.code_x, is_subsystem_code=self._is_subsystem_code)
+        if self._logical_ops is not None:
+            code.set_logical_ops_xz(self.get_logical_ops(Pauli.Z), self.get_logical_ops(Pauli.X))
+        if self._stabilizer_ops is not None:
+            code._stabilizer_ops = (
+                self._stabilizer_ops.reshape(-1, 2, len(self))[:, ::-1, :]
+                .reshape(-1, 2 * len(self))
+                .view(self.field)
+            )
+        if self._gauge_ops is not None:
+            code._gauge_ops = scipy.linalg.block_diag(
+                self.get_gauge_ops(Pauli.Z), self.get_gauge_ops(Pauli.X)
+            ).view(self.field)
+        return code
 
     def deformed(
         self, circuit: str | stim.Circuit, *, preserve_logicals: bool = False

--- a/qldpc/codes/common.py
+++ b/qldpc/codes/common.py
@@ -1356,12 +1356,12 @@ class QuditCode(AbstractCode):
             symplectic_conjugate(x) @ y, which is zero iff x and y represent a pair of Pauli strings
             that commute.
 
-        A quantum code C can then be defined as the set of all symplectic vectors that represent the
+        A quantum code C can be defined as the set of all symplectic vectors that represent the
         logical Pauli operators of the code.  The dual code ~C is then
             ~C = { y : symplectic_conjugate(x) @ y = 0 for all x in C }.
-        In words: the dual code consists of all operators that commute with the logical operators of
-        the original code.  The logical operators of the dual code are therefore (a) the stabilizers
-        and gauge operators of the original code.
+        In words, the dual code consists of all operators that commute with the logical operators of
+        the original code.  The logical operators of the dual code are therefore the stabilizers and
+        gauge operators of the original code.
         """
         matrix = np.vstack([self.get_stabilizer_ops(), self.get_logical_ops()])
         code = QuditCode(matrix, is_subsystem_code=self.dimension != 0)

--- a/qldpc/codes/common.py
+++ b/qldpc/codes/common.py
@@ -1370,6 +1370,11 @@ class QuditCode(AbstractCode):
         code._gauge_ops = self._logical_ops
         return code
 
+    def get_dual_subsystem_code(self) -> QuditCode:  # pragma: no cover
+        """Deprecated alias for self.dual()."""
+        warnings.warn("QuditCode.get_dual_subsystem_code is DEPRECATED; use QuditCode.dual instead")
+        return self.dual()
+
     @functools.cached_property
     def dimension(self) -> int:
         """The number of logical qudits encoded by this code."""

--- a/qldpc/codes/common.py
+++ b/qldpc/codes/common.py
@@ -362,8 +362,8 @@ class ClassicalCode(AbstractCode):
         """Dual to this code.
 
         The dual code ~C is the set of bitstrings orthogonal to C:
-        ~C = { x : x @ y = 0 for all y in C }.
-        The parity check matrix of ~C is equal to the generator of C.
+            ~C = { y : x @ y = 0 for all x in C }.
+        The generator of C (i.e., the matrix whose rows span C) is the parity check matrix of ~C.
         """
         return ClassicalCode(self.generator)
 
@@ -1335,11 +1335,34 @@ class QuditCode(AbstractCode):
         if self._gauge_ops is not None:
             return self._gauge_ops
 
-        self._gauge_ops = self.get_dual_subsystem_code().get_logical_ops()
+        self._gauge_ops = self.dual().get_logical_ops()
         return self._gauge_ops
 
-    def get_dual_subsystem_code(self) -> QuditCode:
-        """Get the subsystem code that swaps gauge and logical qudits of this code."""
+    def dual(self) -> QuditCode:
+        """Dual to this code, which swaps the roles of logical and gauge operators.
+
+        The dual of a quantum code is defined almost identically to the dual a classical code.
+
+        In the classical case, a code C is defined as a set of bitstrings, { x : x in C }.  The dual
+        code ~C is then the set of bitstrings that are orthogonal to C:
+            ~C = { y : x @ y = 0 for all x in C }.
+        This definition is equivalent to saying that the generator of C (a matrix whose rows span C)
+        is the parity check matrix of ~C, and vice versa.
+
+        To analogously define the dual of a quantum code, we need to:
+        (1) Represent Pauli strings by symplectic vectors that indicate the support of
+            (single-qudit) X and Z Pauli operators.
+        (2) Replace the ordinary inner product x @ y by the symplectic inner product,
+            symplectic_conjugate(x) @ y, which is zero iff x and y represent a pair of Pauli strings
+            that commute.
+
+        A quantum code C can then be defined as the set of all symplectic vectors that represent the
+        logical Pauli operators of the code.  The dual code ~C is then
+            ~C = { y : symplectic_conjugate(x) @ y = 0 for all x in C }.
+        In words: the dual code consists of all operators that commute with the logical operators of
+        the original code.  The logical operators of the dual code are therefore (a) the stabilizers
+        and gauge operators of the original code.
+        """
         matrix = np.vstack([self.get_stabilizer_ops(), self.get_logical_ops()])
         code = QuditCode(matrix, is_subsystem_code=self.dimension != 0)
         code._stabilizer_ops = self._stabilizer_ops
@@ -2282,8 +2305,11 @@ class CSSCode(QuditCode):
             return gauge_ops
         return gauge_ops.reshape(-1, 2, len(self))[:, pauli, :].view(self.field)
 
-    def get_dual_subsystem_code(self) -> CSSCode:
-        """Get the subsystem code that swaps gauge and logical qudits of this code."""
+    def dual(self) -> CSSCode:
+        """Dual to this code, which swaps the roles of logical and gauge operators.
+
+        See help(qldpc.codes.QuditCode.dual) for an explanation.
+        """
         matrix_x = np.vstack([self.get_stabilizer_ops(Pauli.X), self.get_logical_ops(Pauli.X)])
         matrix_z = np.vstack([self.get_stabilizer_ops(Pauli.Z), self.get_logical_ops(Pauli.Z)])
         code = CSSCode(matrix_x, matrix_z, is_subsystem_code=self.dimension != 0)

--- a/qldpc/codes/common.py
+++ b/qldpc/codes/common.py
@@ -1511,13 +1511,12 @@ class QuditCode(AbstractCode):
             raise ValueError(f"Arguments not recognized for distance bounding: {bound_kwargs}")
         return external.codes.get_distance_bound(self, num_trials, cutoff=cutoff, maxav=maxav)
 
-    def conjugated(self, qudits: slice | Sequence[int] | None = None) -> QuditCode:
+    def conjugated(self, qudits: slice | Sequence[int]) -> QuditCode:
         """Apply local Fourier transforms, swapping X-type and Z-type operators.
 
         Args:
-            qudits: The qudits to transform, or None for all qudits.  Default: None.
+            qudits: The qudits to transform.
         """
-        qudits = qudits if qudits is not None else slice(len(self))
 
         def transform_ops(ops: galois.FieldArray) -> galois.FieldArray:
             """Fourier-transform the given Pauli strings."""
@@ -1537,7 +1536,7 @@ class QuditCode(AbstractCode):
 
     def conjugate(self) -> QuditCode:
         """The same code with all X-type and Z-type operators swapped."""
-        return self.conjugated()
+        return self.conjugated(range(len(self)))
 
     def deformed(
         self, circuit: str | stim.Circuit, *, preserve_logicals: bool = False
@@ -2616,11 +2615,11 @@ class CSSCode(QuditCode):
             for logical_index in range(self.dimension):
                 self.reduce_logical_op(pauli, logical_index, **decoder_kwargs)
 
-    def conjugated(self, qudits: slice | Sequence[int] | None = None) -> QuditCode:
+    def conjugated(self, qudits: slice | Sequence[int]) -> QuditCode:
         """Apply local Fourier transforms, swapping X-type and Z-type operators.
 
         Args:
-            qudits: The qudits to transform, or None for all qudits.  Default: None.
+            qudits: The qudits to transform.
         """
         return super().conjugated(qudits).maybe_to_css()
 

--- a/qldpc/codes/common_test.py
+++ b/qldpc/codes/common_test.py
@@ -615,7 +615,7 @@ def test_css_deformations() -> None:
     code: codes.CSSCode
 
     code = codes.SteaneCode()
-    assert codes.CSSCode.equiv(code.conjugated(), code)
+    assert codes.CSSCode.equiv(code.conjugated(range(len(code))), code)
     assert not codes.CSSCode.equiv(code.deformed("H 0"), code)
 
     code = codes.SHYPSCode(2)

--- a/qldpc/codes/common_test.py
+++ b/qldpc/codes/common_test.py
@@ -364,7 +364,7 @@ def test_qudit_deformations() -> None:
     code.get_stabilizer_ops()
     code.get_gauge_ops()
     assert code == code.conjugated([]) == code.deformed("")
-    assert code.conjugated() == code.deformed("H " + " ".join(map(str, range(len(code)))))
+    assert code.conjugate() == code.deformed("H " + " ".join(map(str, range(len(code)))))
 
     with pytest.raises(ValueError, match="only supported for qubit codes"):
         codes.QuditCode(code.matrix, field=3).deformed("")
@@ -612,9 +612,17 @@ def test_distance_css() -> None:
 
 def test_css_deformations() -> None:
     """Local Fourier transforms of a CSSCode."""
+    code: codes.CSSCode
+
     code = codes.SteaneCode()
     assert codes.CSSCode.equiv(code.conjugated(), code)
     assert not codes.CSSCode.equiv(code.deformed("H 0"), code)
+
+    code = codes.SHYPSCode(2)
+    code.get_logical_ops()
+    code.get_stabilizer_ops()
+    code.get_gauge_ops()
+    assert code.conjugate() == code.deformed("H " + " ".join(map(str, range(len(code)))))
 
 
 def test_stacking_css_codes() -> None:


### PR DESCRIPTION
Inspired by [this answer](https://www.linkedin.com/feed/update/urn:li:activity:7372388858019340288?commentUrn=urn%3Ali%3Acomment%3A%28activity%3A7372388858019340288%2C7372410478708445184%29&replyUrn=urn%3Ali%3Acomment%3A%28activity%3A7372388858019340288%2C7372417375561973760%29&dashCommentUrn=urn%3Ali%3Afsd_comment%3A%287372410478708445184%2Curn%3Ali%3Aactivity%3A7372388858019340288%29&dashReplyUrn=urn%3Ali%3Afsd_comment%3A%287372417375561973760%2Curn%3Ali%3Aactivity%3A7372388858019340288%29) to [this question](https://www.linkedin.com/posts/dillonmontero_been-trying-to-do-a-literature-search-and-activity-7372388858019340288-FW0x?utm_source=share&utm_medium=member_desktop&rcm=ACoAAAsz0DEBkzdCiKElJIsP-E9nqs2eIWVrQC4).