### PR TITLE
Allow setting X-type logicals of a CSS code, determining the Z-type logicals automatically

### DIFF
--- a/qldpc/codes/common_test.py
+++ b/qldpc/codes/common_test.py
@@ -539,11 +539,16 @@ def test_css_ops() -> None:
 
     code = codes.SHPCode(codes.ClassicalCode.random(4, 2, field=3))
 
-    # swap around logical operators
-    code.set_logical_ops_xz(
-        code.get_logical_ops(Pauli.X)[::-1],
-        code.get_logical_ops(Pauli.Z)[::-1],
-    )
+    # set X-type logicals and determine Z-type logicals automatically
+    other_code = codes.CSSCode(code.matrix_x, code.matrix_z)
+    other_code.set_logical_ops_x(code.get_logical_ops(Pauli.X))
+    assert np.array_equal(code.get_logical_ops(Pauli.X), other_code.get_logical_ops(Pauli.X))
+    assert np.array_equal(code.get_logical_ops(Pauli.Z), other_code.get_logical_ops(Pauli.Z))
+
+    # shuffle logical operators around
+    code.set_logical_ops_z(code.get_logical_ops(Pauli.Z)[::-1])
+    assert np.array_equal(code.get_logical_ops(Pauli.X), other_code.get_logical_ops(Pauli.X)[::-1])
+    assert np.array_equal(code.get_logical_ops(Pauli.Z), other_code.get_logical_ops(Pauli.Z)[::-1])
 
     # identify stabilizer group
     code._stabilizer_ops = None


### PR DESCRIPTION
We previously had `CSSCode.set_logical_ops_xz`.  This method was redundant in that once X-type logicals are defined, there is no choice of Z-type logicals, and vice versa.

This PR adds `CSSCode.set_logical_ops_x` and `CSSCode.set_logical_ops_z`, which automate the construction of logicals in one sector once the logicals in the other sector are defined.

Still a TODO (in a future PR) is to fill in `QuditCode.set_logical_ops_[x|z]`, which currently raise a `NotImplementedError`.  These methods are somewhat more mathematically involved, but look like a fun linear algebra problem to solve sometime.