### PR TITLE
Allow passing a cutoff to `QuditCode.get_distance_exact`

### DIFF
--- a/qldpc/codes/common.py
+++ b/qldpc/codes/common.py
@@ -435,13 +435,14 @@ class ClassicalCode(AbstractCode):
         return self.get_distance_bound(num_trials=int(bound), vector=vector, **bound_kwargs)
 
     def get_distance_exact(
-        self, *, vector: Sequence[int] | npt.NDArray[np.int_] | None = None
+        self, *, vector: Sequence[int] | npt.NDArray[np.int_] | None = None, cutoff: int = 1
     ) -> int | float:
         """Compute the minimum Hamming weight of nontrivial code words by brute force.
 
         Args:
             vector: If not None, rather than computing the code distance, compute the minimum
                 Hamming distance between this vector and a code word.  Default: None.
+            cutoff: Exit and return once an upper bound on distance falls to or below this cutoff.
 
         Returns:
             An integer distance if it is defined, or np.nan otherwise.
@@ -449,17 +450,32 @@ class ClassicalCode(AbstractCode):
         if (known_distance := self.get_distance_if_known(vector)) is not None:
             return known_distance
 
-        if vector is not None:
-            vector = np.asarray(vector, dtype=int).view(self.field)
-            return min(np.count_nonzero(word - vector) for word in self.iter_words())
-
         # we do not know the exact distance, so compute it
-        if self.field.order == 2:
-            distance = get_distance_classical(self.generator)
+        if self.field.order == 2 and vector is None:
+            distance = get_distance_classical(self.generator, cutoff=cutoff)
+            if cutoff <= 1:
+                self._distance = int(distance)
+
+        elif vector is None:
+            distance = len(self)
+            for word in self.iter_words(skip_zero=True):
+                distance = min(distance, np.count_nonzero(word))
+                if distance <= cutoff:
+                    break
+            if cutoff <= 1:
+                self._distance = int(distance)
+
         else:
-            distance = min(np.count_nonzero(word) for word in self.iter_words(skip_zero=True))
-        self._distance = int(distance)
-        return self._distance
+            vector = np.asarray(vector).view(self.field)
+            if not np.any(self.matrix @ vector):
+                return 0
+            distance = np.count_nonzero(vector)
+            for word in self.iter_words(skip_zero=True):
+                distance = min(distance, np.count_nonzero(word - vector))
+                if distance <= cutoff:
+                    break
+
+        return distance
 
     def get_distance_if_known(
         self, vector: Sequence[int] | npt.NDArray[np.int_] | None = None
@@ -1459,8 +1475,11 @@ class QuditCode(AbstractCode):
             return self.get_distance_exact()
         return self.get_distance_bound(num_trials=int(bound), **bound_kwargs)
 
-    def get_distance_exact(self) -> int | float:
+    def get_distance_exact(self, *, cutoff: int = 1) -> int | float:
         """Compute the minimum weight of nontrivial logical operators by brute force.
+
+        Args:
+            cutoff: Exit and return once an upper bound on distance falls to or below this cutoff.
 
         Returns:
             An integer distance if it is defined, or np.nan otherwise.
@@ -1475,7 +1494,10 @@ class QuditCode(AbstractCode):
             stabilizers = np.vstack([stabilizers, self.get_gauge_ops()]).view(self.field)
 
         if self.field.order == 2:
-            distance = get_distance_quantum(logical_ops, stabilizers, homogeneous=False)
+            distance = get_distance_quantum(
+                logical_ops, stabilizers, cutoff=cutoff, homogeneous=False
+            )
+
         else:
             warnings.warn(
                 "Computing the exact distance of a non-binary code may take a (very) long time"
@@ -1491,8 +1513,11 @@ class QuditCode(AbstractCode):
                 support_x = word[: len(self)].view(np.ndarray)
                 support_z = word[len(self) :].view(np.ndarray)
                 distance = min(distance, np.count_nonzero(support_x | support_z))
+                if distance <= cutoff:
+                    break
 
-        self._distance = int(distance)
+        if cutoff <= 1:
+            self._distance = int(distance)
         return distance
 
     def get_distance_if_known(self) -> int | float | None:
@@ -2417,13 +2442,14 @@ class CSSCode(QuditCode):
             return self.get_distance_exact(pauli)
         return self.get_distance_bound(num_trials=int(bound), pauli=pauli, **bound_kwargs)
 
-    def get_distance_exact(self, pauli: PauliXZ | None = None) -> int | float:
+    def get_distance_exact(self, pauli: PauliXZ | None = None, *, cutoff: int = 1) -> int | float:
         """Compute the minimum weight of nontrivial logical operators by brute force.
 
         Args:
             pauli: If passed qldpc.objects.Pauli.X, compute the X-distance (minimum weight of an
                 X-type logical operator).  If passed qldpc.objects.Pauli.X, compute the Z-distance.
                 If None (the default), minimize over X and Z.
+            cutoff: Exit and return once an upper bound on distance falls to or below this cutoff.
 
         Returns:
             An integer distance if it is defined, or np.nan otherwise.
@@ -2447,26 +2473,34 @@ class CSSCode(QuditCode):
             stabilizers = np.vstack([stabilizers, self.get_gauge_ops(pauli)]).view(self.field)
 
         if self.field.order == 2:
-            distance = get_distance_quantum(logical_ops, stabilizers, homogeneous=True)
+            distance = get_distance_quantum(
+                logical_ops, stabilizers, cutoff=cutoff, homogeneous=True
+            )
+
         else:
             warnings.warn(
                 "Computing the exact distance of a non-binary code may take a (very) long time"
             )
+            distance = len(self)
             code_logical_ops = ClassicalCode.from_generator(logical_ops)
             code_stabilizers = ClassicalCode.from_generator(stabilizers)
-            distance = min(
-                np.count_nonzero(word_l + word_s)
-                for word_l in code_logical_ops.iter_words(skip_zero=True)
-                for word_s in code_stabilizers.iter_words()
-            )
+            for word_l, word_s in itertools.product(
+                code_logical_ops.iter_words(skip_zero=True),
+                code_stabilizers.iter_words(),
+            ):
+                distance = min(distance, np.count_nonzero(word_l + word_s))
+                if distance <= cutoff:
+                    break
 
-        # save the exact distance and return
-        if pauli is Pauli.X or self._equal_distance_xz:
-            self._distance_x = distance
-        if pauli is Pauli.Z or self._equal_distance_xz:
-            self._distance_z = distance
-        if self._distance_x is not None and self._distance_z is not None:
-            self._distance = min(self._distance_x, self._distance_z)
+        if cutoff <= 1:
+            # save the exact distance
+            if pauli is Pauli.X or self._equal_distance_xz:
+                self._distance_x = distance
+            if pauli is Pauli.Z or self._equal_distance_xz:
+                self._distance_z = distance
+            if self._distance_x is not None and self._distance_z is not None:
+                self._distance = min(self._distance_x, self._distance_z)
+
         return distance
 
     def _get_distance_exact(self, pauli: PauliXZ | None) -> int | float:

--- a/qldpc/codes/common.py
+++ b/qldpc/codes/common.py
@@ -2464,7 +2464,10 @@ class CSSCode(QuditCode):
             return distance
 
         if pauli is None:
-            return min(self.get_distance_exact(Pauli.X), self.get_distance_exact(Pauli.Z))
+            return min(
+                self.get_distance_exact(Pauli.X, cutoff=cutoff),
+                self.get_distance_exact(Pauli.Z, cutoff=cutoff),
+            )
 
         # we do not know the exact distance, so compute it
         logical_ops = self.get_logical_ops(pauli)

--- a/qldpc/codes/common_test.py
+++ b/qldpc/codes/common_test.py
@@ -299,6 +299,8 @@ def test_qudit_codes() -> None:
 
 def test_distance_qudit() -> None:
     """Distance calculations."""
+    code: codes.QuditCode
+
     code = codes.FiveQubitCode()
     code._is_subsystem_code = True  # test that this does not break anything
 

--- a/qldpc/codes/common_test.py
+++ b/qldpc/codes/common_test.py
@@ -164,7 +164,7 @@ def test_distance_classical(bits: int = 3) -> None:
     # compute distance of a trinary repetition code
     rep_code = codes.RepetitionCode(bits, field=3)
     rep_code.forget_distance()
-    assert rep_code.get_distance_exact() == 3
+    assert rep_code.get_distance_exact(cutoff=bits) == rep_code.get_distance_exact() == bits
 
 
 def test_conversions_classical(bits: int = 5, checks: int = 3) -> None:
@@ -326,20 +326,22 @@ def test_distance_qudit() -> None:
         pytest.raises(ValueError, match="Arguments not recognized"),
     ):
         code.get_distance(bound=True, test=True)
+
+    # mock computing distance with GAP
     with (
         unittest.mock.patch("qldpc.external.gap.is_installed", return_value=True),
-        unittest.mock.patch("qldpc.external.codes.get_distance_bound", return_value=3),
+        unittest.mock.patch("qldpc.external.codes.get_distance_bound", return_value=-1),
     ):
-        assert code.get_distance(bound=True) == 3
+        assert code.get_distance(bound=True) == -1
 
     # the distance of dimension-0 codes is undefined
     assert codes.QuditCode([[0, 1]]).get_distance() is np.nan
 
     # fallback pythonic brute-force distance calculation
-    surface_code = codes.SurfaceCode(2, field=3)
-    with unittest.mock.patch("qldpc.codes.CSSCode.get_distance_if_known", return_value=None):
-        with pytest.warns(UserWarning, match=r"may take a \(very\) long time"):
-            assert codes.QuditCode.get_distance_exact(surface_code) == 2
+    code = codes.QuditCode(codes.SurfaceCode(2, field=3).matrix)
+    with pytest.warns(UserWarning, match=r"may take a \(very\) long time"):
+        assert code.get_distance_exact(cutoff=len(code)) <= len(code)
+        assert code.get_distance_exact() == 2
 
 
 @pytest.mark.parametrize("field", [2, 3])
@@ -579,41 +581,37 @@ def test_distance_css() -> None:
     """Distance calculations for CSS codes."""
     code: codes.CSSCode
 
-    code = codes.SteaneCode()
-    code.forget_distance()
-    assert code.get_distance() == 3
+    # code = codes.SteaneCode()
+    # code.forget_distance()
+    # assert code.get_distance() == 3
+
+    # qubit code distance
+    code = codes.QuditCode(codes.SHPCode(codes.RepetitionCode(2)).matrix).to_css()
+    assert code.get_distance_exact(cutoff=len(code)) <= len(code)
+    assert code.get_distance_exact() == 2
+    assert code.get_distance_bound_with_decoder(Pauli.X, cutoff=len(code)) <= len(code)
+
+    # computing an exact distance but providing bounding arguments raises a warning
+    with pytest.warns(UserWarning, match="ignored"):
+        assert code.get_distance(bound=False, test_arg=True)
 
     # qutrit code distance
     code = codes.HGPCode(codes.RepetitionCode(2, field=3))
+    code.forget_distance()
     assert code.get_distance(bound=False) == 2
 
+    code = codes.QuditCode(code.matrix).to_css()
+    assert code.get_distance_bound(cutoff=len(code)) <= len(code)
+    with unittest.mock.patch("qldpc.external.gap.is_installed", return_value=False):
+        assert code.get_distance(bound=True) <= len(code)
     with (
-        unittest.mock.patch("qldpc.codes.CSSCode.get_distance_if_known", return_value=None),
-        unittest.mock.patch("qldpc.codes.HGPCode._get_distance_exact", return_value=NotImplemented),
+        unittest.mock.patch("qldpc.external.gap.is_installed", return_value=True),
+        unittest.mock.patch("qldpc.external.codes.get_distance_bound", return_value=-1),
     ):
-        with pytest.warns(UserWarning, match=r"may take a \(very\) long time"):
-            assert code.get_distance(bound=False) == 2
-
-        assert code.get_distance_bound(cutoff=len(code)) == len(code)
-        with unittest.mock.patch("qldpc.external.gap.is_installed", return_value=False):
-            assert code.get_distance(bound=True) <= len(code)
-        with (
-            unittest.mock.patch("qldpc.external.gap.is_installed", return_value=True),
-            unittest.mock.patch("qldpc.external.codes.get_distance_bound", return_value=-1),
-        ):
-            assert code.get_distance(bound=True) == -1
-
-    # qubit code distance
-    code = codes.SHPCode(codes.RepetitionCode(2))
-    with unittest.mock.patch(
-        "qldpc.codes.SHPCode._get_distance_exact", return_value=NotImplemented
-    ):
+        assert code.get_distance(bound=True) == -1
+    with pytest.warns(UserWarning, match=r"may take a \(very\) long time"):
+        assert code.get_distance_exact(cutoff=len(code)) <= len(code)
         assert code.get_distance_exact() == 2
-        assert code.get_distance_bound_with_decoder(Pauli.X, cutoff=len(code)) <= len(code)
-
-        # computing an exact distance but providing bounding arguments raises a warning
-        with pytest.warns(UserWarning, match="ignored"):
-            assert code.get_distance(bound=False, test_arg=True)
 
     # the distance of a dimension-0 quantum code is undefined
     trivial_code = codes.ClassicalCode([[1, 0], [1, 1]])


### PR DESCRIPTION
The exact distance calculation will stop and return early if an upper bound on distance drops to or below this cutoff.  In this case, the returned value is the upper bound.