### PR TITLE
Allow passing an error_channel to a LookupDecoder

### DIFF
--- a/qldpc/decoders/custom_test.py
+++ b/qldpc/decoders/custom_test.py
@@ -26,7 +26,6 @@ import galois
 import numpy as np
 import pytest
 import scipy.sparse
-import stim
 
 from qldpc import codes, decoders
 from qldpc.math import symplectic_conjugate
@@ -169,10 +168,7 @@ def test_quantum_decoding(pytestconfig: pytest.Config) -> None:
 
 
 def test_penalty_func() -> None:
-    """Lookup tables can build penalty functions for detector error models."""
-    dem = stim.DetectorErrorModel("""
-        error(0.2) D0
-        error(0.1) D1
-    """)
-    penalty_func = decoders.LookupDecoder.build_penalty_func(dem)
+    """Lookup tables can build penalty functions that penalize unlikely errors."""
+    error_channel = [0.2, 0.1]
+    penalty_func = decoders.LookupDecoder.build_penalty_func(error_channel)
     assert penalty_func([0, 0]) < penalty_func([1, 0]) < penalty_func([0, 1]) < penalty_func([1, 1])

--- a/qldpc/decoders/sinter.py
+++ b/qldpc/decoders/sinter.py
@@ -61,7 +61,8 @@ class SinterDecoder(sinter.Decoder):
         if self.priors_arg is None:
             # address some known cases
             if (
-                decoder_kwargs.get("with_BP_OSD")
+                decoder_kwargs.get("with_lookup")
+                or decoder_kwargs.get("with_BP_OSD")
                 or decoder_kwargs.get("with_BP_LSD")
                 or decoder_kwargs.get("with_BF")
             ):


### PR DESCRIPTION
The LookupDecoder will automatically build a maximum-likelihood penalty function