### PR TITLE
Add capability to post-select detector error models

### DIFF
--- a/qldpc/decoders/dems.py
+++ b/qldpc/decoders/dems.py
@@ -72,16 +72,12 @@ class DetectorErrorModelArrays:
         detector_flip_matrix: scipy.sparse.csc_matrix | npt.NDArray[np.float64],
         observable_flip_matrix: scipy.sparse.csc_matrix | npt.NDArray[np.float64],
         error_probs: npt.NDArray[np.float64],
-        *,
-        simplify: bool = True,
     ) -> DetectorErrorModelArrays:
         """Initialize from arrays directly."""
         dem_arrays = object.__new__(DetectorErrorModelArrays)
         dem_arrays.detector_flip_matrix = scipy.sparse.csc_matrix(detector_flip_matrix)
         dem_arrays.observable_flip_matrix = scipy.sparse.csc_matrix(observable_flip_matrix)
         dem_arrays.error_probs = np.asarray(error_probs)
-        if simplify:
-            dem_arrays.simplify()
         return dem_arrays
 
     @property
@@ -166,6 +162,10 @@ class DetectorErrorModelArrays:
 
         return detector_flip_matrix.tocsc(), observable_flip_matrix.tocsc(), error_probs
 
+    def to_dem(self) -> stim.DetectorErrorModel:
+        """Alias for self.to_detector_error_model()."""
+        return self.to_detector_error_model()
+
     def to_detector_error_model(self) -> stim.DetectorErrorModel:
         """Convert this object into a stim.DetectorErrorModel."""
         dem = stim.DetectorErrorModel()
@@ -186,9 +186,20 @@ class DetectorErrorModelArrays:
 
         return dem
 
-    def simplify(self) -> DetectorErrorModelArrays:
+    def simplified(self) -> DetectorErrorModelArrays:
         """Simplify this DetectorErrorModelArrays object by merging errors."""
         return DetectorErrorModelArrays(self.to_detector_error_model(), simplify=True)
+
+    def post_selected_on(self, *detectors: int) -> DetectorErrorModelArrays:
+        """Post-select on the given detectors, removing error mechanisms that trigger them."""
+        mask = self.detector_flip_matrix[detectors].getnnz(axis=0) == 0
+        detectors_to_keep = np.ones(self.num_detectors, dtype=bool)
+        detectors_to_keep[detectors] = False
+        return DetectorErrorModelArrays.from_arrays(
+            self.detector_flip_matrix[detectors_to_keep][:, mask],
+            self.observable_flip_matrix[:, mask],
+            self.error_probs[mask],
+        )
 
 
 def _values_that_occur_an_odd_number_of_times(items: Collection[int]) -> frozenset[int]:

--- a/qldpc/decoders/dems_test.py
+++ b/qldpc/decoders/dems_test.py
@@ -35,7 +35,7 @@ def test_initialization() -> None:
         error(0.003) D2 L1
     """)
     dem_arrays = decoders.DetectorErrorModelArrays(dem)
-    assert dem.approx_equals(dem_arrays.to_detector_error_model(), atol=1e-10)
+    assert dem.approx_equals(dem_arrays.to_dem(), atol=1e-10)
     assert dem_arrays.num_errors == 3
     assert dem_arrays.num_detectors == 3
     assert dem_arrays.num_observables == 2
@@ -99,4 +99,23 @@ def test_simplify() -> None:
         error(0.3) D1
     """)
     assert dem == dem_arrays.to_detector_error_model()
-    assert simplified_dem == dem_arrays.simplify().to_detector_error_model()
+    assert simplified_dem == dem_arrays.simplified().to_detector_error_model()
+
+
+def test_post_selection() -> None:
+    """Post select on some detectors."""
+    dem = stim.DetectorErrorModel("""
+        detector D0
+        detector D1
+        logical_observable L0
+        logical_observable L1
+        error(0.3) D0 D1 L0
+        error(0.3) D1 L1
+    """)
+    post_selected_dem = stim.DetectorErrorModel("""
+        detector D0
+        logical_observable L0
+        logical_observable L1
+        error(0.3) D0 L1
+    """)
+    assert post_selected_dem == decoders.DetectorErrorModelArrays(dem).post_selected_on(0).to_dem()


### PR DESCRIPTION
Post-selection replaces the `exclusions` argument to `CompositeSinterDecoder`, so this PR effectively reverts #376 