### PR TITLE
Build the DetectorRecord after post-selection

### DIFF
--- a/qldpc/circuits/bookkeeping_test.py
+++ b/qldpc/circuits/bookkeeping_test.py
@@ -84,3 +84,10 @@ def test_records() -> None:
         record_copy = record.copy()
         assert isinstance(record_copy, type(record))
         assert list(record_copy.items()) == list(record.items())
+
+
+def test_post_selection() -> None:
+    """Update a DetectorRecord after post-selecting on some detectors."""
+    record = circuits.DetectorRecord({"flag": [0, 2, 4], "a": [1, 5], "b": [3]})
+    expected_record = circuits.DetectorRecord({"a": [0, 2], "b": [1]})
+    assert record.after_post_selection("flag") == expected_record


### PR DESCRIPTION
From the docstring:
```
        If "detector_record" is the record of the detectors in circuit whose detector error model is
        represented by the qldpc.decoders.DetectorErrorModelArrays object "dem_arrays", the record
            new_detector_record = detector_record.after_post_selection(key)
        is the record of the detectors in
            new_dem_arrays = dem_arrays.post_selected_on(detector_record.get_events(key))
        See help(qldpc.decoders.DetectorErrorModelArrays).

```