### PR TITLE
Add a generic `StimCircuitLike` type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
   "sinter>=1.16",
   "stim>=1.16",
   "sympy>=1.12",
+  "typing-extensions>=4",
 ]
 optional-dependencies.dev = [
   "checks-superstaq>=0.5.67",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ optional-dependencies.dev = [
   "pypandoc-binary>=1.13",        # bundles pandoc for building the notebook docs locally
   "pyproject-fmt>=2",             # pyproject.toml formatting, run by checks/format_.py
   "python-lsp-server[all]>=1.14",
-  "qldpc[docs,relay-bp,tsim]",
+  "qldpc[docs,relay-bp]",
 ]
 optional-dependencies.docs = [
   "ipython>=8",          # for nbsphinx's IPython.sphinxext.ipython_console_highlighting extension
@@ -59,7 +59,6 @@ optional-dependencies.docs = [
   "sphinx-rtd-theme>=2",
 ]
 optional-dependencies.relay-bp = [ "relay-bp[stim]==0.2.1" ]
-optional-dependencies.tsim = [ "bloqade-tsim>=0.1.4" ]
 urls.Repository = "https://github.com/qLDPCOrg/qLDPC"
 
 # Check script configuration:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
   "typing-extensions>=4",
 ]
 optional-dependencies.dev = [
-  "checks-superstaq>=0.5.67",
+  "checks-superstaq>=0.5.62",
   "jupyter>=1.1.1",
   "pypandoc-binary>=1.13",        # bundles pandoc for building the notebook docs locally
   "pyproject-fmt>=2",             # pyproject.toml formatting, run by checks/format_.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
   "sympy>=1.12",
 ]
 optional-dependencies.dev = [
-  "checks-superstaq>=0.5.62",
+  "checks-superstaq>=0.5.67",
   "jupyter>=1.1.1",
   "pypandoc-binary>=1.13",        # bundles pandoc for building the notebook docs locally
   "pyproject-fmt>=2",             # pyproject.toml formatting, run by checks/format_.py

--- a/src/qldpc/circuits/__init__.py
+++ b/src/qldpc/circuits/__init__.py
@@ -10,6 +10,8 @@ from .bookkeeping import (
     Record,
 )
 from .common import (
+    StimCircuitLike,
+    StimCircuitProtocol,
     get_pauli_product_measurements,
     get_unaddressed_measurements,
     remap_qubit_target,
@@ -71,6 +73,8 @@ __all__ = [
     "QubitIDs",
     "Record",
     "SI1000NoiseModel",
+    "StimCircuitLike",
+    "StimCircuitProtocol",
     "SyndromeMeasurementStrategy",
     "as_noiseless_circuit",
     "get_encoder_and_decoder",

--- a/src/qldpc/circuits/common.py
+++ b/src/qldpc/circuits/common.py
@@ -19,8 +19,7 @@ from __future__ import annotations
 
 import functools
 from collections.abc import Callable, Mapping, Sequence
-from types import ModuleType
-from typing import TYPE_CHECKING, ParamSpec, TypeVar
+from typing import ParamSpec, TypeVar
 
 import galois
 import numpy as np
@@ -28,30 +27,7 @@ import numpy.typing as npt
 import stim
 
 from qldpc import codes, math
-
-####################################################################################################
-# define a circuit type that may be either a stim.Circuit or an (optional) tsim.Circuit
-
-if TYPE_CHECKING:
-    import tsim
-
-    stim_or_tsim_Circuit = TypeVar("stim_or_tsim_Circuit", stim.Circuit, tsim.Circuit)
-else:
-    stim_or_tsim_Circuit = TypeVar("stim_or_tsim_Circuit", bound=stim.Circuit)
-
-
-def _load_tsim_if_installed() -> ModuleType | None:
-    """Lazily import the optional tsim package, returning None if it is not installed."""
-    try:
-        import tsim
-
-        return tsim
-    except ImportError:  # pragma: no cover
-        return None
-
-
-####################################################################################################
-
+from qldpc.objects import StimCircuitLike, StimWrappingCircuit
 
 CircuitOrTableau = TypeVar("CircuitOrTableau", stim.Circuit, stim.Tableau)
 Params = ParamSpec("Params")
@@ -72,11 +48,11 @@ def restrict_to_qubits(
 
 
 def with_remapped_qubits(
-    circuit: stim_or_tsim_Circuit,
+    circuit: StimCircuitLike,
     qubit_map: Mapping[int, int] | Sequence[int],
     *,
     inverse: bool = False,
-) -> stim_or_tsim_Circuit:
+) -> StimCircuitLike:
     """The same circuit, but with relabeled qubits.
 
     Qubits not in qubit_map get mapped to themselves.
@@ -90,14 +66,11 @@ def with_remapped_qubits(
     Returns:
         The input circuit with remapped qubits.
     """
-    tsim = _load_tsim_if_installed()
-    if tsim is not None and isinstance(circuit, tsim.Circuit):
+    if not isinstance(circuit, stim.Circuit):
+        # a stim-wrapping circuit: unwrap to its stim.Circuit, remap that, and rebuild its type
+        assert isinstance(circuit, StimWrappingCircuit)
         output = with_remapped_qubits(circuit.stim_circuit, qubit_map, inverse=inverse)
-        return tsim.Circuit.from_stim_program(output)
-
-    # tsim loads lazily, so `tsim.Circuit` above is untyped and does not narrow `circuit`; having
-    # ruled out a tsim circuit, the remaining possibility for the type variable is a stim.Circuit
-    assert isinstance(circuit, stim.Circuit)
+        return type(circuit).from_stim_program(output)
 
     qubit_map = (
         qubit_map

--- a/src/qldpc/circuits/common.py
+++ b/src/qldpc/circuits/common.py
@@ -33,6 +33,19 @@ CircuitOrTableau = TypeVar("CircuitOrTableau", stim.Circuit, stim.Tableau)
 Params = ParamSpec("Params")
 
 
+def _rebuilt_as(template: StimCircuitLike, circuit: stim.Circuit) -> StimCircuitLike:
+    """Return the contents of a ``stim.Circuit`` as a circuit of the same type as ``template``.
+
+    Used by circuit-polymorphic functions to convert a freshly-built ``stim.Circuit`` back into the
+    concrete type of their input: this constructs an empty circuit of that type and appends the
+    ``stim.Circuit`` to it, relying only on ``StimCircuitProtocol`` (empty construction and
+    in-place concatenation).  When ``template`` is itself a ``stim.Circuit``, this returns a copy.
+    """
+    output = type(template)()
+    output += circuit
+    return output
+
+
 def restrict_to_qubits(
     func: Callable[Params, CircuitOrTableau],
 ) -> Callable[Params, CircuitOrTableau]:
@@ -70,7 +83,7 @@ def with_remapped_qubits(
         # a stim-wrapping circuit: unwrap to its stim.Circuit, remap that, and rebuild its type
         assert isinstance(circuit, StimWrappingCircuit)
         output = with_remapped_qubits(circuit.stim_circuit, qubit_map, inverse=inverse)
-        return type(circuit).from_stim_program(output)
+        return _rebuilt_as(circuit, output)
 
     qubit_map = (
         qubit_map

--- a/src/qldpc/circuits/common.py
+++ b/src/qldpc/circuits/common.py
@@ -120,9 +120,6 @@ def with_remapped_qubits(
     if inverse:
         qubit_map = {val: key for key, val in qubit_map.items()}
 
-    # Build the remapped circuit as the same concrete type as the input, reading the input's
-    # operations by index.  This works uniformly for a stim.Circuit and for any stim-wrapping
-    # circuit (which iterates as, and accepts appends of, stim operations) without unwrapping.
     new_circuit = type(circuit)()
     for index in range(len(circuit)):
         op = circuit[index]

--- a/src/qldpc/circuits/common.py
+++ b/src/qldpc/circuits/common.py
@@ -18,19 +18,65 @@ limitations under the License.
 from __future__ import annotations
 
 import functools
-from collections.abc import Callable, Mapping, Sequence
-from typing import ParamSpec, TypeVar
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from typing import ParamSpec, Protocol, TypeVar
 
 import galois
 import numpy as np
 import numpy.typing as npt
 import stim
+from typing_extensions import Self
 
 from qldpc import codes, math
-from qldpc.objects import StimCircuitLike
 
 CircuitOrTableau = TypeVar("CircuitOrTableau", stim.Circuit, stim.Tableau)
 Params = ParamSpec("Params")
+
+
+class StimCircuitProtocol(Protocol):
+    """Structural type for circuit objects that behave like a ``stim.Circuit``.
+
+    A ``stim.Circuit`` satisfies this protocol, as do stim-wrapping circuit classes such as
+    ``tsim.Circuit``.  qLDPC's circuit-polymorphic functions (e.g. ``noisy_circuit``,
+    ``with_remapped_qubits``) are generic over the ``StimCircuitLike`` type variable (bound to this
+    protocol) so that they preserve the concrete circuit type of their input.  Those functions read
+    a circuit as a sequence of ``stim`` operations (via ``range(len(circuit))`` and indexing), do
+    their work on a ``stim.Circuit``, and rebuild a circuit of the original type by constructing an
+    empty instance (``type(circuit)()``) and populating it via ``append`` / in-place concatenation.
+    A conforming circuit must therefore be default-constructible in addition to supporting the
+    methods declared here.  This lets qLDPC support such circuits structurally, without depending on
+    the packages that define them.
+    """
+
+    def append(
+        self,
+        name: str | stim.CircuitInstruction | stim.CircuitRepeatBlock | stim.Circuit,
+        targets: (
+            int
+            | stim.GateTarget
+            | stim.PauliString
+            | Iterable[int | stim.GateTarget | stim.PauliString]
+        ) = (),
+        arg: float | Iterable[float] | None = None,
+        *,
+        tag: str = "",
+    ) -> None:
+        """Append an operation to this circuit in place."""
+
+    def __iadd__(self, other: stim.Circuit) -> Self:
+        """Append another circuit to this circuit in place."""
+
+    def __getitem__(self, index: int) -> stim.CircuitInstruction | stim.CircuitRepeatBlock:
+        """The operation at the given index."""
+
+    def __len__(self) -> int:
+        """The number of operations in this circuit."""
+
+
+# A type variable for a circuit that behaves like a stim.Circuit (see StimCircuitProtocol).  Used to
+# type functions that are generic over stim.Circuit and stim-wrapping circuits while preserving the
+# concrete circuit type of their input.
+StimCircuitLike = TypeVar("StimCircuitLike", bound=StimCircuitProtocol)
 
 
 def restrict_to_qubits(

--- a/src/qldpc/circuits/common.py
+++ b/src/qldpc/circuits/common.py
@@ -33,19 +33,6 @@ CircuitOrTableau = TypeVar("CircuitOrTableau", stim.Circuit, stim.Tableau)
 Params = ParamSpec("Params")
 
 
-def _rebuilt_as(template: StimCircuitLike, circuit: stim.Circuit) -> StimCircuitLike:
-    """Return the contents of a ``stim.Circuit`` as a circuit of the same type as ``template``.
-
-    Used by circuit-polymorphic functions to convert a freshly-built ``stim.Circuit`` back into the
-    concrete type of their input: this constructs an empty circuit of that type and appends the
-    ``stim.Circuit`` to it, relying only on ``StimCircuitProtocol`` (empty construction and
-    in-place concatenation).  When ``template`` is itself a ``stim.Circuit``, this returns a copy.
-    """
-    output = type(template)()
-    output += circuit
-    return output
-
-
 def restrict_to_qubits(
     func: Callable[Params, CircuitOrTableau],
 ) -> Callable[Params, CircuitOrTableau]:

--- a/src/qldpc/circuits/common.py
+++ b/src/qldpc/circuits/common.py
@@ -27,7 +27,7 @@ import numpy.typing as npt
 import stim
 
 from qldpc import codes, math
-from qldpc.objects import StimCircuitLike, StimWrappingCircuit
+from qldpc.objects import StimCircuitLike
 
 CircuitOrTableau = TypeVar("CircuitOrTableau", stim.Circuit, stim.Tableau)
 Params = ParamSpec("Params")
@@ -79,12 +79,6 @@ def with_remapped_qubits(
     Returns:
         The input circuit with remapped qubits.
     """
-    if not isinstance(circuit, stim.Circuit):
-        # a stim-wrapping circuit: unwrap to its stim.Circuit, remap that, and rebuild its type
-        assert isinstance(circuit, StimWrappingCircuit)
-        output = with_remapped_qubits(circuit.stim_circuit, qubit_map, inverse=inverse)
-        return _rebuilt_as(circuit, output)
-
     qubit_map = (
         qubit_map
         if isinstance(qubit_map, Mapping)
@@ -93,8 +87,12 @@ def with_remapped_qubits(
     if inverse:
         qubit_map = {val: key for key, val in qubit_map.items()}
 
-    new_circuit = stim.Circuit()
-    for op in circuit:
+    # Build the remapped circuit as the same concrete type as the input, reading the input's
+    # operations by index.  This works uniformly for a stim.Circuit and for any stim-wrapping
+    # circuit (which iterates as, and accepts appends of, stim operations) without unwrapping.
+    new_circuit = type(circuit)()
+    for index in range(len(circuit)):
+        op = circuit[index]
         if isinstance(op, stim.CircuitRepeatBlock):
             block = stim.CircuitRepeatBlock(
                 repeat_count=op.repeat_count,

--- a/src/qldpc/circuits/common.py
+++ b/src/qldpc/circuits/common.py
@@ -120,7 +120,7 @@ def with_remapped_qubits(
     if inverse:
         qubit_map = {val: key for key, val in qubit_map.items()}
 
-    new_circuit = type(circuit)()
+    new_circuit = type(circuit)()  # same type as input circuit
     for index in range(len(circuit)):
         op = circuit[index]
         if isinstance(op, stim.CircuitRepeatBlock):

--- a/src/qldpc/circuits/common_test.py
+++ b/src/qldpc/circuits/common_test.py
@@ -25,7 +25,7 @@ import stim
 import sympy.combinatorics as comb
 
 from qldpc import circuits, codes
-from qldpc.circuits.conftest import StimWrappingCircuit
+from qldpc.circuits.conftest import StimCircuitWrapper
 from qldpc.math import symplectic_conjugate
 from qldpc.objects import Pauli
 
@@ -97,8 +97,8 @@ def test_qubit_remap(pytestconfig: pytest.Config, num_qubits: int = 8) -> None:
     assert circuit_a == circuit_b
 
     # a stim-wrapping circuit input is remapped and returned as the same wrapping type
-    wrapped_remapped = circuits.with_remapped_qubits(StimWrappingCircuit(circuit), qubit_map)
-    assert isinstance(wrapped_remapped, StimWrappingCircuit)
+    wrapped_remapped = circuits.with_remapped_qubits(StimCircuitWrapper(circuit), qubit_map)
+    assert isinstance(wrapped_remapped, StimCircuitWrapper)
     assert wrapped_remapped.stim_circuit == circuits.with_remapped_qubits(circuit, qubit_map)
 
 

--- a/src/qldpc/circuits/common_test.py
+++ b/src/qldpc/circuits/common_test.py
@@ -23,25 +23,11 @@ import numpy as np
 import pytest
 import stim
 import sympy.combinatorics as comb
-from typing_extensions import Self
 
 from qldpc import circuits, codes
+from qldpc.circuits.conftest import StimWrappingCircuit
 from qldpc.math import symplectic_conjugate
 from qldpc.objects import Pauli
-
-
-class _WrappingCircuit:
-    """A minimal stim-wrapping circuit (like tsim.Circuit) exercising StimWrappingCircuit."""
-
-    def __init__(self, stim_circuit: stim.Circuit | None = None) -> None:
-        self.stim_circuit = stim.Circuit() if stim_circuit is None else stim_circuit
-
-    def append(self, *args: object, **kwargs: object) -> None:  # pragma: no cover
-        self.stim_circuit.append(*args, **kwargs)
-
-    def __iadd__(self, other: stim.Circuit) -> Self:
-        self.stim_circuit += other
-        return self
 
 
 def test_restriction() -> None:
@@ -111,8 +97,8 @@ def test_qubit_remap(pytestconfig: pytest.Config, num_qubits: int = 8) -> None:
     assert circuit_a == circuit_b
 
     # a stim-wrapping circuit input is remapped and returned as the same wrapping type
-    wrapped_remapped = circuits.with_remapped_qubits(_WrappingCircuit(circuit), qubit_map)
-    assert isinstance(wrapped_remapped, _WrappingCircuit)
+    wrapped_remapped = circuits.with_remapped_qubits(StimWrappingCircuit(circuit), qubit_map)
+    assert isinstance(wrapped_remapped, StimWrappingCircuit)
     assert wrapped_remapped.stim_circuit == circuits.with_remapped_qubits(circuit, qubit_map)
 
 

--- a/src/qldpc/circuits/common_test.py
+++ b/src/qldpc/circuits/common_test.py
@@ -33,17 +33,13 @@ from qldpc.objects import Pauli
 class _WrappingCircuit:
     """A minimal stim-wrapping circuit (like tsim.Circuit) exercising StimWrappingCircuit."""
 
-    def __init__(self, stim_circuit: stim.Circuit) -> None:
-        self.stim_circuit = stim_circuit
-
-    @classmethod
-    def from_stim_program(cls, stim_circuit: stim.Circuit) -> Self:
-        return cls(stim_circuit.copy())
+    def __init__(self, stim_circuit: stim.Circuit | None = None) -> None:
+        self.stim_circuit = stim.Circuit() if stim_circuit is None else stim_circuit
 
     def append(self, *args: object, **kwargs: object) -> None:  # pragma: no cover
         self.stim_circuit.append(*args, **kwargs)
 
-    def __iadd__(self, other: stim.Circuit) -> Self:  # pragma: no cover
+    def __iadd__(self, other: stim.Circuit) -> Self:
         self.stim_circuit += other
         return self
 

--- a/src/qldpc/circuits/common_test.py
+++ b/src/qldpc/circuits/common_test.py
@@ -18,16 +18,34 @@ limitations under the License.
 from __future__ import annotations
 
 import random
+from typing import Self
 
 import numpy as np
 import pytest
 import stim
 import sympy.combinatorics as comb
-import tsim
 
 from qldpc import circuits, codes
 from qldpc.math import symplectic_conjugate
 from qldpc.objects import Pauli
+
+
+class _WrappingCircuit:
+    """A minimal stim-wrapping circuit (like tsim.Circuit) exercising StimWrappingCircuit."""
+
+    def __init__(self, stim_circuit: stim.Circuit) -> None:
+        self.stim_circuit = stim_circuit
+
+    @classmethod
+    def from_stim_program(cls, stim_circuit: stim.Circuit) -> Self:
+        return cls(stim_circuit.copy())
+
+    def append(self, *args: object, **kwargs: object) -> None:  # pragma: no cover
+        self.stim_circuit.append(*args, **kwargs)
+
+    def __iadd__(self, other: stim.Circuit) -> Self:  # pragma: no cover
+        self.stim_circuit += other
+        return self
 
 
 def test_restriction() -> None:
@@ -96,12 +114,10 @@ def test_qubit_remap(pytestconfig: pytest.Config, num_qubits: int = 8) -> None:
     circuit_b = stim.Circuit("MPP X1*!Y3 \n M !4")
     assert circuit_a == circuit_b
 
-    # a tsim.Circuit input is remapped and returned as a tsim.Circuit
-    tsim_remapped = circuits.with_remapped_qubits(
-        tsim.Circuit.from_stim_program(circuit), qubit_map
-    )
-    assert isinstance(tsim_remapped, tsim.Circuit)
-    assert tsim_remapped.stim_circuit == circuits.with_remapped_qubits(circuit, qubit_map)
+    # a stim-wrapping circuit input is remapped and returned as the same wrapping type
+    wrapped_remapped = circuits.with_remapped_qubits(_WrappingCircuit(circuit), qubit_map)
+    assert isinstance(wrapped_remapped, _WrappingCircuit)
+    assert wrapped_remapped.stim_circuit == circuits.with_remapped_qubits(circuit, qubit_map)
 
 
 def test_finding_unaddressed_measurements() -> None:

--- a/src/qldpc/circuits/common_test.py
+++ b/src/qldpc/circuits/common_test.py
@@ -18,12 +18,12 @@ limitations under the License.
 from __future__ import annotations
 
 import random
-from typing import Self
 
 import numpy as np
 import pytest
 import stim
 import sympy.combinatorics as comb
+from typing_extensions import Self
 
 from qldpc import circuits, codes
 from qldpc.math import symplectic_conjugate

--- a/src/qldpc/circuits/conftest.py
+++ b/src/qldpc/circuits/conftest.py
@@ -21,7 +21,7 @@ import stim
 from typing_extensions import Self
 
 
-class StimWrappingCircuit:
+class StimCircuitWrapper:
     """A minimal stim-wrapping circuit (like tsim.Circuit) for exercising StimCircuitProtocol.
 
     It satisfies StimCircuitProtocol (append / __iadd__ / indexing / len) and is

--- a/src/qldpc/circuits/conftest.py
+++ b/src/qldpc/circuits/conftest.py
@@ -1,0 +1,47 @@
+"""Shared pytest helpers for circuits tests.
+
+Copyright 2023 The qLDPC Authors and Infleqtion Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from __future__ import annotations
+
+import stim
+from typing_extensions import Self
+
+
+class StimWrappingCircuit:
+    """A minimal stim-wrapping circuit (like tsim.Circuit) for exercising StimCircuitProtocol.
+
+    It satisfies StimCircuitProtocol (append / __iadd__ / indexing / len) and is
+    default-constructible, so circuit-polymorphic functions accept it and return the same type.
+    The ``stim_circuit`` attribute is not required by those functions; it just lets tests read back
+    the wrapped circuit to check results.
+    """
+
+    def __init__(self, stim_circuit: stim.Circuit | None = None) -> None:
+        self.stim_circuit = stim.Circuit() if stim_circuit is None else stim_circuit
+
+    def append(self, *args: object, **kwargs: object) -> None:
+        self.stim_circuit.append(*args, **kwargs)
+
+    def __iadd__(self, other: stim.Circuit) -> Self:
+        self.stim_circuit += other
+        return self
+
+    def __getitem__(self, index: int) -> stim.CircuitInstruction | stim.CircuitRepeatBlock:
+        return self.stim_circuit[index]
+
+    def __len__(self) -> int:
+        return len(self.stim_circuit)

--- a/src/qldpc/circuits/noise_model.py
+++ b/src/qldpc/circuits/noise_model.py
@@ -1092,8 +1092,7 @@ class NoiseModel:
             The input circuit with added noise.
         """
         if not isinstance(circuit, stim.Circuit):
-            # a stim-wrapping circuit: read its operations into a stim.Circuit, add noise, and
-            # rebuild a circuit of the same type
+            # convert to stim, add noise, convert back
             stim_input = stim.Circuit()
             for index in range(len(circuit)):
                 stim_input.append(circuit[index])

--- a/src/qldpc/circuits/noise_model.py
+++ b/src/qldpc/circuits/noise_model.py
@@ -125,7 +125,7 @@ import stim
 from qldpc._util import format_docstring
 from qldpc.objects import StimCircuitLike
 
-from .common import _rebuilt_as, with_remapped_qubits
+from .common import with_remapped_qubits
 
 ####################################################################################################
 # global constants
@@ -1097,7 +1097,7 @@ class NoiseModel:
             stim_input = stim.Circuit()
             for index in range(len(circuit)):
                 stim_input.append(circuit[index])
-            output = self.noisy_circuit(
+            stim_output = self.noisy_circuit(
                 stim_input,
                 system_qubits=system_qubits,
                 immune_qubits=immune_qubits,
@@ -1105,7 +1105,9 @@ class NoiseModel:
                 immunize_gates=immunize_gates,
                 insert_ticks=insert_ticks,
             )
-            return _rebuilt_as(circuit, output)
+            output = type(circuit)()
+            output += stim_output
+            return output
 
         system_qubits = frozenset(
             range(circuit.num_qubits) if system_qubits is None else system_qubits

--- a/src/qldpc/circuits/noise_model.py
+++ b/src/qldpc/circuits/noise_model.py
@@ -125,7 +125,7 @@ import stim
 from qldpc._util import format_docstring
 from qldpc.objects import StimCircuitLike, StimWrappingCircuit
 
-from .common import with_remapped_qubits
+from .common import _rebuilt_as, with_remapped_qubits
 
 ####################################################################################################
 # global constants
@@ -243,7 +243,7 @@ def as_noiseless_circuit(circuit: StimCircuitLike) -> StimCircuitLike:
         # a stim-wrapping circuit: unwrap to its stim.Circuit, process that, and rebuild its type
         assert isinstance(circuit, StimWrappingCircuit)
         output = as_noiseless_circuit(circuit.stim_circuit)
-        return type(circuit).from_stim_program(output)
+        return _rebuilt_as(circuit, output)
 
     block = stim.CircuitRepeatBlock(repeat_count=1, body=circuit.copy(), tag=DEFAULT_IMMUNE_OP_TAG)
     noiseless_circuit = stim.Circuit()
@@ -1102,7 +1102,7 @@ class NoiseModel:
                 immunize_gates=immunize_gates,
                 insert_ticks=insert_ticks,
             )
-            return type(circuit).from_stim_program(output)
+            return _rebuilt_as(circuit, output)
 
         system_qubits = frozenset(
             range(circuit.num_qubits) if system_qubits is None else system_qubits

--- a/src/qldpc/circuits/noise_model.py
+++ b/src/qldpc/circuits/noise_model.py
@@ -123,7 +123,7 @@ from typing import TypeAlias, overload
 import stim
 
 from qldpc._util import format_docstring
-from qldpc.objects import StimCircuitLike, StimWrappingCircuit
+from qldpc.objects import StimCircuitLike
 
 from .common import _rebuilt_as, with_remapped_qubits
 
@@ -239,14 +239,14 @@ CORRELATED_ERROR_NAMES = frozenset({"CORRELATED_ERROR", "E", "ELSE_CORRELATED_ER
 
 def as_noiseless_circuit(circuit: StimCircuitLike) -> StimCircuitLike:
     """Wrap a circuit in a noiseless, one-repetition stim.CircuitRepeatBlock."""
-    if not isinstance(circuit, stim.Circuit):
-        # a stim-wrapping circuit: unwrap to its stim.Circuit, process that, and rebuild its type
-        assert isinstance(circuit, StimWrappingCircuit)
-        output = as_noiseless_circuit(circuit.stim_circuit)
-        return _rebuilt_as(circuit, output)
+    # Read the circuit's operations into a stim.Circuit body (the repeat block requires a
+    # stim.Circuit).  Iterating by index works for a stim.Circuit and any stim-wrapping circuit.
+    body = stim.Circuit()
+    for index in range(len(circuit)):
+        body.append(circuit[index])
 
-    block = stim.CircuitRepeatBlock(repeat_count=1, body=circuit.copy(), tag=DEFAULT_IMMUNE_OP_TAG)
-    noiseless_circuit = stim.Circuit()
+    block = stim.CircuitRepeatBlock(repeat_count=1, body=body, tag=DEFAULT_IMMUNE_OP_TAG)
+    noiseless_circuit = type(circuit)()
     noiseless_circuit.append(block)
     return noiseless_circuit
 
@@ -1092,10 +1092,13 @@ class NoiseModel:
             The input circuit with added noise.
         """
         if not isinstance(circuit, stim.Circuit):
-            # a stim-wrapping circuit: unwrap to its stim.Circuit, add noise, and rebuild its type
-            assert isinstance(circuit, StimWrappingCircuit)
+            # a stim-wrapping circuit: read its operations into a stim.Circuit, add noise, and
+            # rebuild a circuit of the same type
+            stim_input = stim.Circuit()
+            for index in range(len(circuit)):
+                stim_input.append(circuit[index])
             output = self.noisy_circuit(
-                circuit.stim_circuit,
+                stim_input,
                 system_qubits=system_qubits,
                 immune_qubits=immune_qubits,
                 immune_op_tag=immune_op_tag,

--- a/src/qldpc/circuits/noise_model.py
+++ b/src/qldpc/circuits/noise_model.py
@@ -123,9 +123,8 @@ from typing import TypeAlias, overload
 import stim
 
 from qldpc._util import format_docstring
-from qldpc.objects import StimCircuitLike
 
-from .common import with_remapped_qubits
+from .common import StimCircuitLike, with_remapped_qubits
 
 ####################################################################################################
 # global constants

--- a/src/qldpc/circuits/noise_model.py
+++ b/src/qldpc/circuits/noise_model.py
@@ -1,4 +1,4 @@
-"""Implementation of noise models for Stim (and tsim) circuits.
+"""Implementation of noise models for stim circuits (and stim-wrapping circuits such as tsim's).
 
 The main components of this module are:
 
@@ -118,13 +118,14 @@ import itertools
 import math
 import re
 from collections.abc import Callable, Collection, Iterable, Iterator, Mapping
-from typing import TypeAlias
+from typing import TypeAlias, overload
 
 import stim
 
 from qldpc._util import format_docstring
+from qldpc.objects import StimCircuitLike, StimWrappingCircuit
 
-from .common import _load_tsim_if_installed, stim_or_tsim_Circuit, with_remapped_qubits
+from .common import with_remapped_qubits
 
 ####################################################################################################
 # global constants
@@ -236,12 +237,14 @@ CORRELATED_ERROR_NAMES = frozenset({"CORRELATED_ERROR", "E", "ELSE_CORRELATED_ER
 # primary methods and classes: as_noiseless_circuit, PauliChannel, NoiseRule, NoiseModel
 
 
-def as_noiseless_circuit(circuit: stim_or_tsim_Circuit) -> stim_or_tsim_Circuit:
+def as_noiseless_circuit(circuit: StimCircuitLike) -> StimCircuitLike:
     """Wrap a circuit in a noiseless, one-repetition stim.CircuitRepeatBlock."""
-    tsim = _load_tsim_if_installed()
-    if tsim is not None and isinstance(circuit, tsim.Circuit):
+    if not isinstance(circuit, stim.Circuit):
+        # a stim-wrapping circuit: unwrap to its stim.Circuit, process that, and rebuild its type
+        assert isinstance(circuit, StimWrappingCircuit)
         output = as_noiseless_circuit(circuit.stim_circuit)
-        return tsim.Circuit.from_stim_program(output)
+        return type(circuit).from_stim_program(output)
+
     block = stim.CircuitRepeatBlock(repeat_count=1, body=circuit.copy(), tag=DEFAULT_IMMUNE_OP_TAG)
     noiseless_circuit = stim.Circuit()
     noiseless_circuit.append(block)
@@ -348,8 +351,8 @@ class AbstractPauliChannel(abc.ABC):
         return self._probabilities
 
     def _resolve_targets(
-        self, append_to: stim_or_tsim_Circuit | None, qubits: Iterable[int] | None
-    ) -> tuple[stim_or_tsim_Circuit, list[int]]:
+        self, append_to: StimCircuitLike | None, qubits: Iterable[int] | None
+    ) -> tuple[StimCircuitLike, list[int]]:
         """Resolve the ``(circuit, qubit_targets)`` pair shared by every variant of ``to_circuit``.
 
         Creates a fresh circuit when ``append_to`` is ``None``, defaults ``qubits`` to
@@ -363,14 +366,28 @@ class AbstractPauliChannel(abc.ABC):
             )
         return circuit, qubit_targets
 
+    @overload
+    def to_circuit(
+        self, *, append_to: None = None, qubits: Iterable[int] | None = None, tag: str = ""
+    ) -> stim.Circuit: ...
+
+    @overload
+    def to_circuit(
+        self,
+        *,
+        append_to: StimCircuitLike,
+        qubits: Iterable[int] | None = None,
+        tag: str = "",
+    ) -> StimCircuitLike: ...
+
     @abc.abstractmethod
     def to_circuit(
         self,
         *,
-        append_to: stim_or_tsim_Circuit | None = None,
+        append_to: StimCircuitLike | None = None,
         qubits: Iterable[int] | None = None,
         tag: str = "",
-    ) -> stim_or_tsim_Circuit:
+    ) -> StimCircuitLike:
         """Convert this channel into a circuit."""
 
 
@@ -467,14 +484,34 @@ class PauliChannel(AbstractPauliChannel):
             }
         return result
 
+    @overload
     def to_circuit(
         self,
         *,
-        append_to: stim_or_tsim_Circuit | None = None,
+        append_to: None = None,
         qubits: Iterable[int] | None = None,
         simplify: bool = True,
         tag: str = "",
-    ) -> stim_or_tsim_Circuit:
+    ) -> stim.Circuit: ...
+
+    @overload
+    def to_circuit(
+        self,
+        *,
+        append_to: StimCircuitLike,
+        qubits: Iterable[int] | None = None,
+        simplify: bool = True,
+        tag: str = "",
+    ) -> StimCircuitLike: ...
+
+    def to_circuit(
+        self,
+        *,
+        append_to: StimCircuitLike | None = None,
+        qubits: Iterable[int] | None = None,
+        simplify: bool = True,
+        tag: str = "",
+    ) -> StimCircuitLike:
         """Convert this PauliChannel into a circuit.
 
         If provided a circuit, append to that circuit in-place and return it.
@@ -563,13 +600,27 @@ class PauliChannelSequence(AbstractPauliChannel):
     its own, and several may fire together.
     """
 
+    @overload
+    def to_circuit(
+        self, *, append_to: None = None, qubits: Iterable[int] | None = None, tag: str = ""
+    ) -> stim.Circuit: ...
+
+    @overload
     def to_circuit(
         self,
         *,
-        append_to: stim_or_tsim_Circuit | None = None,
+        append_to: StimCircuitLike,
         qubits: Iterable[int] | None = None,
         tag: str = "",
-    ) -> stim_or_tsim_Circuit:
+    ) -> StimCircuitLike: ...
+
+    def to_circuit(
+        self,
+        *,
+        append_to: StimCircuitLike | None = None,
+        qubits: Iterable[int] | None = None,
+        tag: str = "",
+    ) -> StimCircuitLike:
         """Emit each entry of this channel as an independent ``CORRELATED_ERROR``.
 
         If provided a circuit, append to that circuit in-place and return it.
@@ -722,7 +773,7 @@ class NoiseRule:
         return noisy_op, noise_after
 
     def emit_after(
-        self, circuit: stim_or_tsim_Circuit, qubit_targets: list[int], *, context: str = "operation"
+        self, circuit: StimCircuitLike, qubit_targets: list[int], *, context: str = "operation"
     ) -> None:
         """Append this rule's ``after`` noise in-place to the provided circuit.
 
@@ -1010,14 +1061,14 @@ class NoiseModel:
     @format_docstring(DEFAULT_IMMUNE_OP_TAG=DEFAULT_IMMUNE_OP_TAG)
     def noisy_circuit(
         self,
-        circuit: stim_or_tsim_Circuit,
+        circuit: StimCircuitLike,
         *,
         system_qubits: Iterable[int] | None = None,
         immune_qubits: Iterable[int] = (),
         immune_op_tag: str = DEFAULT_IMMUNE_OP_TAG,
         immunize_gates: bool = True,
         insert_ticks: bool = True,
-    ) -> stim_or_tsim_Circuit:
+    ) -> StimCircuitLike:
         """Construct a noisy version of the given circuit.
 
         This method first uses TICKs to split the input circuit into moments of operations that can
@@ -1040,8 +1091,9 @@ class NoiseModel:
         Returns:
             The input circuit with added noise.
         """
-        tsim = _load_tsim_if_installed()
-        if tsim is not None and isinstance(circuit, tsim.Circuit):
+        if not isinstance(circuit, stim.Circuit):
+            # a stim-wrapping circuit: unwrap to its stim.Circuit, add noise, and rebuild its type
+            assert isinstance(circuit, StimWrappingCircuit)
             output = self.noisy_circuit(
                 circuit.stim_circuit,
                 system_qubits=system_qubits,
@@ -1050,7 +1102,7 @@ class NoiseModel:
                 immunize_gates=immunize_gates,
                 insert_ticks=insert_ticks,
             )
-            return tsim.Circuit.from_stim_program(output)
+            return type(circuit).from_stim_program(output)
 
         system_qubits = frozenset(
             range(circuit.num_qubits) if system_qubits is None else system_qubits

--- a/src/qldpc/circuits/noise_model_test.py
+++ b/src/qldpc/circuits/noise_model_test.py
@@ -1074,17 +1074,13 @@ def test_trivial_noise() -> None:
 class _WrappingCircuit:
     """A minimal stim-wrapping circuit (like tsim.Circuit) exercising StimWrappingCircuit."""
 
-    def __init__(self, stim_circuit: stim.Circuit) -> None:
-        self.stim_circuit = stim_circuit
-
-    @classmethod
-    def from_stim_program(cls, stim_circuit: stim.Circuit) -> Self:
-        return cls(stim_circuit.copy())
+    def __init__(self, stim_circuit: stim.Circuit | None = None) -> None:
+        self.stim_circuit = stim.Circuit() if stim_circuit is None else stim_circuit
 
     def append(self, *args: object, **kwargs: object) -> None:  # pragma: no cover
         self.stim_circuit.append(*args, **kwargs)
 
-    def __iadd__(self, other: stim.Circuit) -> Self:  # pragma: no cover
+    def __iadd__(self, other: stim.Circuit) -> Self:
         self.stim_circuit += other
         return self
 

--- a/src/qldpc/circuits/noise_model_test.py
+++ b/src/qldpc/circuits/noise_model_test.py
@@ -17,10 +17,10 @@ limitations under the License.
 
 import copy
 import pickle
-from typing import Self
 
 import pytest
 import stim
+from typing_extensions import Self
 
 from qldpc import circuits
 

--- a/src/qldpc/circuits/noise_model_test.py
+++ b/src/qldpc/circuits/noise_model_test.py
@@ -22,7 +22,7 @@ import pytest
 import stim
 
 from qldpc import circuits
-from qldpc.circuits.conftest import StimWrappingCircuit
+from qldpc.circuits.conftest import StimCircuitWrapper
 
 
 def _circuits_are_equivalent(
@@ -1076,18 +1076,18 @@ def test_wrapping_circuits() -> None:
     noise_model = circuits.DepolarizingNoiseModel(0.01)
 
     stim_circuit = stim.Circuit("H 0\nCX 0 1\nM 0 1")
-    wrapped_circuit = StimWrappingCircuit(stim_circuit)
+    wrapped_circuit = StimCircuitWrapper(stim_circuit)
 
     stim_noisy = noise_model.noisy_circuit(stim_circuit)
     wrapped_noisy = noise_model.noisy_circuit(wrapped_circuit)
     assert isinstance(stim_noisy, stim.Circuit)
-    assert isinstance(wrapped_noisy, StimWrappingCircuit)
+    assert isinstance(wrapped_noisy, StimCircuitWrapper)
     assert stim_noisy == wrapped_noisy.stim_circuit
 
     stim_noiseless = circuits.as_noiseless_circuit(stim_circuit)
     wrapped_noiseless = circuits.as_noiseless_circuit(wrapped_circuit)
     assert isinstance(stim_noiseless, stim.Circuit)
-    assert isinstance(wrapped_noiseless, StimWrappingCircuit)
+    assert isinstance(wrapped_noiseless, StimCircuitWrapper)
     assert stim_noiseless == wrapped_noiseless.stim_circuit
 
 

--- a/src/qldpc/circuits/noise_model_test.py
+++ b/src/qldpc/circuits/noise_model_test.py
@@ -20,9 +20,9 @@ import pickle
 
 import pytest
 import stim
-from typing_extensions import Self
 
 from qldpc import circuits
+from qldpc.circuits.conftest import StimWrappingCircuit
 
 
 def _circuits_are_equivalent(
@@ -1071,37 +1071,23 @@ def test_trivial_noise() -> None:
     assert bool(circuits.NoiseModel(rule_func=lambda op: None))
 
 
-class _WrappingCircuit:
-    """A minimal stim-wrapping circuit (like tsim.Circuit) exercising StimWrappingCircuit."""
-
-    def __init__(self, stim_circuit: stim.Circuit | None = None) -> None:
-        self.stim_circuit = stim.Circuit() if stim_circuit is None else stim_circuit
-
-    def append(self, *args: object, **kwargs: object) -> None:  # pragma: no cover
-        self.stim_circuit.append(*args, **kwargs)
-
-    def __iadd__(self, other: stim.Circuit) -> Self:
-        self.stim_circuit += other
-        return self
-
-
 def test_wrapping_circuits() -> None:
     """noisy_circuit and as_noiseless_circuit accept and return stim-wrapping circuits."""
     noise_model = circuits.DepolarizingNoiseModel(0.01)
 
     stim_circuit = stim.Circuit("H 0\nCX 0 1\nM 0 1")
-    wrapped_circuit = _WrappingCircuit(stim_circuit)
+    wrapped_circuit = StimWrappingCircuit(stim_circuit)
 
     stim_noisy = noise_model.noisy_circuit(stim_circuit)
     wrapped_noisy = noise_model.noisy_circuit(wrapped_circuit)
     assert isinstance(stim_noisy, stim.Circuit)
-    assert isinstance(wrapped_noisy, _WrappingCircuit)
+    assert isinstance(wrapped_noisy, StimWrappingCircuit)
     assert stim_noisy == wrapped_noisy.stim_circuit
 
     stim_noiseless = circuits.as_noiseless_circuit(stim_circuit)
     wrapped_noiseless = circuits.as_noiseless_circuit(wrapped_circuit)
     assert isinstance(stim_noiseless, stim.Circuit)
-    assert isinstance(wrapped_noiseless, _WrappingCircuit)
+    assert isinstance(wrapped_noiseless, StimWrappingCircuit)
     assert stim_noiseless == wrapped_noiseless.stim_circuit
 
 

--- a/src/qldpc/circuits/noise_model_test.py
+++ b/src/qldpc/circuits/noise_model_test.py
@@ -17,10 +17,10 @@ limitations under the License.
 
 import copy
 import pickle
+from typing import Self
 
 import pytest
 import stim
-import tsim
 
 from qldpc import circuits
 
@@ -1071,23 +1071,42 @@ def test_trivial_noise() -> None:
     assert bool(circuits.NoiseModel(rule_func=lambda op: None))
 
 
-def test_tsim_circuits() -> None:
-    """noisy_circuit and as_noiseless_circuit accept and return tsim.Circuit."""
+class _WrappingCircuit:
+    """A minimal stim-wrapping circuit (like tsim.Circuit) exercising StimWrappingCircuit."""
+
+    def __init__(self, stim_circuit: stim.Circuit) -> None:
+        self.stim_circuit = stim_circuit
+
+    @classmethod
+    def from_stim_program(cls, stim_circuit: stim.Circuit) -> Self:
+        return cls(stim_circuit.copy())
+
+    def append(self, *args: object, **kwargs: object) -> None:  # pragma: no cover
+        self.stim_circuit.append(*args, **kwargs)
+
+    def __iadd__(self, other: stim.Circuit) -> Self:  # pragma: no cover
+        self.stim_circuit += other
+        return self
+
+
+def test_wrapping_circuits() -> None:
+    """noisy_circuit and as_noiseless_circuit accept and return stim-wrapping circuits."""
     noise_model = circuits.DepolarizingNoiseModel(0.01)
 
-    tsim_circuit = tsim.Circuit("H 0\nCX 0 1\nM 0 1")
-    stim_circuit = tsim_circuit.stim_circuit
+    stim_circuit = stim.Circuit("H 0\nCX 0 1\nM 0 1")
+    wrapped_circuit = _WrappingCircuit(stim_circuit)
 
     stim_noisy = noise_model.noisy_circuit(stim_circuit)
-    tsim_noisy = noise_model.noisy_circuit(tsim_circuit)
+    wrapped_noisy = noise_model.noisy_circuit(wrapped_circuit)
     assert isinstance(stim_noisy, stim.Circuit)
-    assert isinstance(tsim_noisy, tsim.Circuit)
-    assert stim_noisy == tsim_noisy.stim_circuit
+    assert isinstance(wrapped_noisy, _WrappingCircuit)
+    assert stim_noisy == wrapped_noisy.stim_circuit
 
     stim_noiseless = circuits.as_noiseless_circuit(stim_circuit)
-    tsim_noiseless = circuits.as_noiseless_circuit(tsim_circuit)
+    wrapped_noiseless = circuits.as_noiseless_circuit(wrapped_circuit)
     assert isinstance(stim_noiseless, stim.Circuit)
-    assert isinstance(tsim_noiseless, tsim.Circuit)
+    assert isinstance(wrapped_noiseless, _WrappingCircuit)
+    assert stim_noiseless == wrapped_noiseless.stim_circuit
 
 
 ####################################################################################################

--- a/src/qldpc/objects.py
+++ b/src/qldpc/objects.py
@@ -34,63 +34,6 @@ from qldpc import abstract
 from qldpc._util import networkx as nx
 
 
-class StimCircuitProtocol(Protocol):
-    """Structural type for circuit objects that behave like a ``stim.Circuit``.
-
-    A ``stim.Circuit`` satisfies this protocol, as do stim-wrapping circuit classes such as
-    ``tsim.Circuit`` (see :class:`StimWrappingCircuit`).  qLDPC's circuit-polymorphic functions
-    (e.g. ``noisy_circuit``, ``with_remapped_qubits``) are generic over the ``StimCircuitLike`` type
-    variable (bound to this protocol), so that they preserve the concrete circuit type of their
-    input.  The protocol declares only the operations those functions invoke directly on a circuit
-    whose concrete type has not yet been narrowed to ``stim.Circuit`` or a wrapping circuit:
-    appending an operation, and in-place concatenation.
-    """
-
-    def append(
-        self,
-        name: str | stim.CircuitInstruction | stim.CircuitRepeatBlock | stim.Circuit,
-        targets: (
-            int
-            | stim.GateTarget
-            | stim.PauliString
-            | Iterable[int | stim.GateTarget | stim.PauliString]
-        ) = (),
-        arg: float | Iterable[float] | None = None,
-        *,
-        tag: str = "",
-    ) -> None:
-        """Append an operation to this circuit in place."""
-
-    def __iadd__(self, other: stim.Circuit) -> Self:
-        """Append another circuit to this circuit in place."""
-
-
-@runtime_checkable
-class StimWrappingCircuit(StimCircuitProtocol, Protocol):
-    """A circuit backed by a ``stim.Circuit`` (e.g. ``tsim.Circuit``), exposing a conversion bridge.
-
-    Circuits that are not themselves ``stim.Circuit`` instances participate in qLDPC's
-    circuit-polymorphic functions by satisfying this protocol: the function unwraps the circuit to
-    its underlying ``stim.Circuit`` via :attr:`stim_circuit`, does its work on that, and rebuilds a
-    circuit of the original type via :meth:`from_stim_program`.  This lets qLDPC support such
-    circuits structurally, without depending on the packages that define them.
-    """
-
-    @property
-    def stim_circuit(self) -> stim.Circuit:
-        """The underlying ``stim.Circuit`` that this circuit wraps."""
-
-    @classmethod
-    def from_stim_program(cls, stim_circuit: stim.Circuit) -> Self:
-        """Build a circuit of this type from a ``stim.Circuit``."""
-
-
-# A type variable for a circuit that behaves like a stim.Circuit (see StimCircuitProtocol).  Used to
-# type functions that are generic over stim.Circuit and stim-wrapping circuits while preserving the
-# concrete circuit type of their input.
-StimCircuitLike = TypeVar("StimCircuitLike", bound=StimCircuitProtocol)
-
-
 class Pauli(enum.Enum):
     """Pauli operators."""
 
@@ -242,6 +185,60 @@ class Node:
     def __str__(self) -> str:
         tag = "d" if self.is_data else "c"
         return f"{tag}_{self.index}"
+
+
+class StimCircuitProtocol(Protocol):
+    """Structural type for circuit objects that behave like a ``stim.Circuit``.
+
+    A ``stim.Circuit`` satisfies this protocol, as do stim-wrapping circuit classes such as
+    ``tsim.Circuit`` (see :class:`StimWrappingCircuit`).  qLDPC's circuit-polymorphic functions
+    (e.g. ``noisy_circuit``, ``with_remapped_qubits``) are generic over the ``StimCircuitLike`` type
+    variable (bound to this protocol), so that they preserve the concrete circuit type of their
+    input.  The protocol declares only the operations those functions invoke directly on a circuit
+    whose concrete type has not yet been narrowed to ``stim.Circuit`` or a wrapping circuit:
+    appending an operation, and in-place concatenation.
+    """
+
+    def append(
+        self,
+        name: str | stim.CircuitInstruction | stim.CircuitRepeatBlock | stim.Circuit,
+        targets: (
+            int
+            | stim.GateTarget
+            | stim.PauliString
+            | Iterable[int | stim.GateTarget | stim.PauliString]
+        ) = (),
+        arg: float | Iterable[float] | None = None,
+        *,
+        tag: str = "",
+    ) -> None:
+        """Append an operation to this circuit in place."""
+
+    def __iadd__(self, other: stim.Circuit) -> Self:
+        """Append another circuit to this circuit in place."""
+
+
+@runtime_checkable
+class StimWrappingCircuit(StimCircuitProtocol, Protocol):
+    """A circuit backed by a ``stim.Circuit`` (e.g. ``tsim.Circuit``), exposing its wrapped circuit.
+
+    Circuits that are not themselves ``stim.Circuit`` instances participate in qLDPC's
+    circuit-polymorphic functions by satisfying this protocol: the function reads the underlying
+    ``stim.Circuit`` via :attr:`stim_circuit`, does its work on that, and rebuilds a circuit of the
+    original type by constructing an empty instance (``type(circuit)()``) and appending the result
+    to it (via ``__iadd__``).  This lets qLDPC support such circuits structurally, without depending
+    on the packages that define them.
+    """
+
+    @property
+    def stim_circuit(self) -> stim.Circuit:
+        """The underlying ``stim.Circuit`` that this circuit wraps."""
+
+
+# A type variable for a circuit that behaves like a stim.Circuit (see StimCircuitProtocol).  Used to
+# type functions that are generic over stim.Circuit and stim-wrapping circuits while preserving the
+# concrete circuit type of their input.
+StimCircuitLike = TypeVar("StimCircuitLike", bound=StimCircuitProtocol)
 
 
 class CayleyComplex:

--- a/src/qldpc/objects.py
+++ b/src/qldpc/objects.py
@@ -22,12 +22,13 @@ import enum
 import functools
 import itertools
 from collections.abc import Collection, Iterable, Iterator, Sequence
-from typing import Literal, Protocol, Self, TypeVar, runtime_checkable
+from typing import Literal, Protocol, TypeVar, runtime_checkable
 
 import galois
 import numpy as np
 import numpy.typing as npt
 import stim
+from typing_extensions import Self
 
 from qldpc import abstract
 from qldpc._util import networkx as nx

--- a/src/qldpc/objects.py
+++ b/src/qldpc/objects.py
@@ -21,14 +21,12 @@ import dataclasses
 import enum
 import functools
 import itertools
-from collections.abc import Collection, Iterable, Iterator, Sequence
-from typing import Literal, Protocol, TypeVar
+from collections.abc import Collection, Iterator, Sequence
+from typing import Literal
 
 import galois
 import numpy as np
 import numpy.typing as npt
-import stim
-from typing_extensions import Self
 
 from qldpc import abstract
 from qldpc._util import networkx as nx

--- a/src/qldpc/objects.py
+++ b/src/qldpc/objects.py
@@ -22,7 +22,7 @@ import enum
 import functools
 import itertools
 from collections.abc import Collection, Iterable, Iterator, Sequence
-from typing import Literal, Protocol, TypeVar, runtime_checkable
+from typing import Literal, Protocol, TypeVar
 
 import galois
 import numpy as np
@@ -191,12 +191,15 @@ class StimCircuitProtocol(Protocol):
     """Structural type for circuit objects that behave like a ``stim.Circuit``.
 
     A ``stim.Circuit`` satisfies this protocol, as do stim-wrapping circuit classes such as
-    ``tsim.Circuit`` (see :class:`StimWrappingCircuit`).  qLDPC's circuit-polymorphic functions
-    (e.g. ``noisy_circuit``, ``with_remapped_qubits``) are generic over the ``StimCircuitLike`` type
-    variable (bound to this protocol), so that they preserve the concrete circuit type of their
-    input.  The protocol declares only the operations those functions invoke directly on a circuit
-    whose concrete type has not yet been narrowed to ``stim.Circuit`` or a wrapping circuit:
-    appending an operation, and in-place concatenation.
+    ``tsim.Circuit``.  qLDPC's circuit-polymorphic functions (e.g. ``noisy_circuit``,
+    ``with_remapped_qubits``) are generic over the ``StimCircuitLike`` type variable (bound to this
+    protocol) so that they preserve the concrete circuit type of their input.  Those functions read
+    a circuit as a sequence of ``stim`` operations (via ``range(len(circuit))`` and indexing), do
+    their work on a ``stim.Circuit``, and rebuild a circuit of the original type by constructing an
+    empty instance (``type(circuit)()``) and populating it via ``append`` / in-place concatenation.
+    A conforming circuit must therefore be default-constructible in addition to supporting the
+    methods declared here.  This lets qLDPC support such circuits structurally, without depending on
+    the packages that define them.
     """
 
     def append(
@@ -217,22 +220,11 @@ class StimCircuitProtocol(Protocol):
     def __iadd__(self, other: stim.Circuit) -> Self:
         """Append another circuit to this circuit in place."""
 
+    def __getitem__(self, index: int) -> stim.CircuitInstruction | stim.CircuitRepeatBlock:
+        """The operation at the given index."""
 
-@runtime_checkable
-class StimWrappingCircuit(StimCircuitProtocol, Protocol):
-    """A circuit backed by a ``stim.Circuit`` (e.g. ``tsim.Circuit``), exposing its wrapped circuit.
-
-    Circuits that are not themselves ``stim.Circuit`` instances participate in qLDPC's
-    circuit-polymorphic functions by satisfying this protocol: the function reads the underlying
-    ``stim.Circuit`` via :attr:`stim_circuit`, does its work on that, and rebuilds a circuit of the
-    original type by constructing an empty instance (``type(circuit)()``) and appending the result
-    to it (via ``__iadd__``).  This lets qLDPC support such circuits structurally, without depending
-    on the packages that define them.
-    """
-
-    @property
-    def stim_circuit(self) -> stim.Circuit:
-        """The underlying ``stim.Circuit`` that this circuit wraps."""
+    def __len__(self) -> int:
+        """The number of operations in this circuit."""
 
 
 # A type variable for a circuit that behaves like a stim.Circuit (see StimCircuitProtocol).  Used to

--- a/src/qldpc/objects.py
+++ b/src/qldpc/objects.py
@@ -21,15 +21,73 @@ import dataclasses
 import enum
 import functools
 import itertools
-from collections.abc import Collection, Iterator, Sequence
-from typing import Literal
+from collections.abc import Collection, Iterable, Iterator, Sequence
+from typing import Literal, Protocol, Self, TypeVar, runtime_checkable
 
 import galois
 import numpy as np
 import numpy.typing as npt
+import stim
 
 from qldpc import abstract
 from qldpc._util import networkx as nx
+
+
+class StimCircuitProtocol(Protocol):
+    """Structural type for circuit objects that behave like a ``stim.Circuit``.
+
+    A ``stim.Circuit`` satisfies this protocol, as do stim-wrapping circuit classes such as
+    ``tsim.Circuit`` (see :class:`StimWrappingCircuit`).  qLDPC's circuit-polymorphic functions
+    (e.g. ``noisy_circuit``, ``with_remapped_qubits``) are generic over the ``StimCircuitLike`` type
+    variable (bound to this protocol), so that they preserve the concrete circuit type of their
+    input.  The protocol declares only the operations those functions invoke directly on a circuit
+    whose concrete type has not yet been narrowed to ``stim.Circuit`` or a wrapping circuit:
+    appending an operation, and in-place concatenation.
+    """
+
+    def append(
+        self,
+        name: str | stim.CircuitInstruction | stim.CircuitRepeatBlock | stim.Circuit,
+        targets: (
+            int
+            | stim.GateTarget
+            | stim.PauliString
+            | Iterable[int | stim.GateTarget | stim.PauliString]
+        ) = (),
+        arg: float | Iterable[float] | None = None,
+        *,
+        tag: str = "",
+    ) -> None:
+        """Append an operation to this circuit in place."""
+
+    def __iadd__(self, other: stim.Circuit) -> Self:
+        """Append another circuit to this circuit in place."""
+
+
+@runtime_checkable
+class StimWrappingCircuit(StimCircuitProtocol, Protocol):
+    """A circuit backed by a ``stim.Circuit`` (e.g. ``tsim.Circuit``), exposing a conversion bridge.
+
+    Circuits that are not themselves ``stim.Circuit`` instances participate in qLDPC's
+    circuit-polymorphic functions by satisfying this protocol: the function unwraps the circuit to
+    its underlying ``stim.Circuit`` via :attr:`stim_circuit`, does its work on that, and rebuilds a
+    circuit of the original type via :meth:`from_stim_program`.  This lets qLDPC support such
+    circuits structurally, without depending on the packages that define them.
+    """
+
+    @property
+    def stim_circuit(self) -> stim.Circuit:
+        """The underlying ``stim.Circuit`` that this circuit wraps."""
+
+    @classmethod
+    def from_stim_program(cls, stim_circuit: stim.Circuit) -> Self:
+        """Build a circuit of this type from a ``stim.Circuit``."""
+
+
+# A type variable for a circuit that behaves like a stim.Circuit (see StimCircuitProtocol).  Used to
+# type functions that are generic over stim.Circuit and stim-wrapping circuits while preserving the
+# concrete circuit type of their input.
+StimCircuitLike = TypeVar("StimCircuitLike", bound=StimCircuitProtocol)
 
 
 class Pauli(enum.Enum):

--- a/src/qldpc/objects.py
+++ b/src/qldpc/objects.py
@@ -187,52 +187,6 @@ class Node:
         return f"{tag}_{self.index}"
 
 
-class StimCircuitProtocol(Protocol):
-    """Structural type for circuit objects that behave like a ``stim.Circuit``.
-
-    A ``stim.Circuit`` satisfies this protocol, as do stim-wrapping circuit classes such as
-    ``tsim.Circuit``.  qLDPC's circuit-polymorphic functions (e.g. ``noisy_circuit``,
-    ``with_remapped_qubits``) are generic over the ``StimCircuitLike`` type variable (bound to this
-    protocol) so that they preserve the concrete circuit type of their input.  Those functions read
-    a circuit as a sequence of ``stim`` operations (via ``range(len(circuit))`` and indexing), do
-    their work on a ``stim.Circuit``, and rebuild a circuit of the original type by constructing an
-    empty instance (``type(circuit)()``) and populating it via ``append`` / in-place concatenation.
-    A conforming circuit must therefore be default-constructible in addition to supporting the
-    methods declared here.  This lets qLDPC support such circuits structurally, without depending on
-    the packages that define them.
-    """
-
-    def append(
-        self,
-        name: str | stim.CircuitInstruction | stim.CircuitRepeatBlock | stim.Circuit,
-        targets: (
-            int
-            | stim.GateTarget
-            | stim.PauliString
-            | Iterable[int | stim.GateTarget | stim.PauliString]
-        ) = (),
-        arg: float | Iterable[float] | None = None,
-        *,
-        tag: str = "",
-    ) -> None:
-        """Append an operation to this circuit in place."""
-
-    def __iadd__(self, other: stim.Circuit) -> Self:
-        """Append another circuit to this circuit in place."""
-
-    def __getitem__(self, index: int) -> stim.CircuitInstruction | stim.CircuitRepeatBlock:
-        """The operation at the given index."""
-
-    def __len__(self) -> int:
-        """The number of operations in this circuit."""
-
-
-# A type variable for a circuit that behaves like a stim.Circuit (see StimCircuitProtocol).  Used to
-# type functions that are generic over stim.Circuit and stim-wrapping circuits while preserving the
-# concrete circuit type of their input.
-StimCircuitLike = TypeVar("StimCircuitLike", bound=StimCircuitProtocol)
-
-
 class CayleyComplex:
     """Left-right Cayley complex, used for constructing quantum Tanner codes.
 


### PR DESCRIPTION
To replace `tsim_or_stim_Circuit`.

The one issue is that we still want some methods to accept and return circuits of the same type.  So if given a `tsim.Circuit`, return a `tsim.Circuit`.  But then we need a common interface to construct circuits of the input type.  I'm not sure how to fix this.  The current fix is the `StimWrappingCircuit`, but that's clearly a tsim-specific hack.

I'll make an attempt to fix this issue before merging.  It should be solvable by assuming only that the `StimCircuitLike ` has the same methods as `stim.Circuit`.