### PR TITLE
Support direct- and semidirect-product lifts for GALA codes

### DIFF
--- a/src/qldpc/abstract/__init__.py
+++ b/src/qldpc/abstract/__init__.py
@@ -17,6 +17,7 @@ from .groups import (
     SpecialLinearGroup,
     SymmetricGroup,
     TrivialGroup,
+    WreathProductGroup,
     resolve_field,
 )
 from .linalg import (
@@ -59,6 +60,7 @@ __all__ = [
     "TrivialGroup",
     "WedderburnArtinComponentTransformer",
     "WedderburnArtinTransformer",
+    "WreathProductGroup",
     "block_diag",
     "get_coefficient_and_exponents",
     "get_howell_dual",

--- a/src/qldpc/abstract/groups.py
+++ b/src/qldpc/abstract/groups.py
@@ -318,6 +318,26 @@ class Group:
         """Direct product of Groups."""
         return functools.reduce(operator.mul, groups * repeat)
 
+    @staticmethod
+    def tensor_product(*groups: Group, repeat: int = 1) -> Group:
+        """Direct product of Groups with lifts combined by Kronecker products."""
+        groups = groups * repeat
+        product = Group.product(*groups)
+        degrees = [group.to_sympy().degree for group in groups]
+
+        def lift(member: GroupMember) -> npt.NDArray[np.int_]:
+            matrices = []
+            offset = 0
+            for group, degree in zip(groups, degrees):
+                array_form = [
+                    value - offset for value in member.array_form[offset : offset + degree]
+                ]
+                matrices.append(group.lift(GroupMember(array_form)))
+                offset += degree
+            return functools.reduce(np.kron, matrices)
+
+        return Group.from_sympy(product.to_sympy(), lift=lift)
+
     def random(self, *, seed: int | None = None) -> GroupMember:
         """A random element this group."""
         with contextlib.ExitStack() as stack:

--- a/src/qldpc/abstract/groups.py
+++ b/src/qldpc/abstract/groups.py
@@ -247,7 +247,11 @@ class Group:
         return new_group
 
     def with_natural_lift(self) -> Group:
-        """Copy this group with its natural permutation representation as the lift."""
+        """Copy this group with its natural permutation representation as the lift.
+
+        The natural lift has the dimension of the set acted on by the group, rather than the order
+        of the group as in the regular representation.
+        """
         group = Group()
         group._init_from_group(self, name=self.name, lift=GroupMember.to_matrix)
         return group
@@ -320,7 +324,12 @@ class Group:
 
     @staticmethod
     def tensor_product(*groups: Group, repeat: int = 1) -> Group:
-        """Direct product of Groups with lifts combined by Kronecker products."""
+        """Direct product of Groups with lifts combined by Kronecker products.
+
+        The underlying group is the same as ``Group.product``, while the selected lift of a product
+        element is the Kronecker product of its factor lifts.  The ``repeat`` argument repeats the
+        entire sequence of factors.
+        """
         groups = groups * repeat
         product = Group.product(*groups)
         degrees = [group.to_sympy().degree for group in groups]
@@ -652,7 +661,8 @@ class WreathProductGroup(Group):
 
     If the top group acts on ``k`` points and the bottom group acts on ``m`` points, an element
     ``(h; c_0, ..., c_{k-1})`` acts on ``k * m`` points by
-    ``(i, j) -> (h(i), c_i(j))``.
+    ``(i, j) -> (h(i), c_i(j))``.  The selected lift is the natural permutation representation on
+    these ``k * m`` points.
     """
 
     top: Group

--- a/src/qldpc/abstract/groups.py
+++ b/src/qldpc/abstract/groups.py
@@ -647,6 +647,76 @@ class Group:
         return output
 
 
+class WreathProductGroup(Group):
+    """Permutational wreath product of a top group and copies of a bottom group.
+
+    If the top group acts on ``k`` points and the bottom group acts on ``m`` points, an element
+    ``(h; c_0, ..., c_{k-1})`` acts on ``k * m`` points by
+    ``(i, j) -> (h(i), c_i(j))``.
+    """
+
+    top: Group
+    bottom: Group
+    top_degree: int
+    bottom_degree: int
+
+    def __init__(self, top: Group, bottom: Group) -> None:
+        self.top = top
+        self.bottom = bottom
+        self.top_degree = top.to_sympy().degree
+        self.bottom_degree = bottom.to_sympy().degree
+        if not self.top_degree or not self.bottom_degree:
+            raise ValueError("Wreath-product groups must act on nonempty sets")
+
+        top_identity = self.top.identity
+        bottom_identity = self.bottom.identity
+        generators = [
+            self.element(generator, [bottom_identity] * self.top_degree)
+            for generator in self.top.generators
+        ]
+        generators += [
+            self.element(
+                top_identity,
+                [
+                    generator if index == block else bottom_identity
+                    for index in range(self.top_degree)
+                ],
+            )
+            for block in range(self.top_degree)
+            for generator in self.bottom.generators
+        ]
+        super().__init__(*generators, lift=GroupMember.to_matrix)
+
+    def element(
+        self,
+        top_member: GroupMember,
+        bottom_members: Sequence[GroupMember],
+    ) -> GroupMember:
+        """Construct a wreath-product element from its top and bottom components.
+
+        Args:
+            top_member: An element of the top group.
+            bottom_members: One bottom-group element for each point acted on by the top group.
+        """
+        bottom_members = tuple(bottom_members)
+        if top_member not in self.top:
+            raise ValueError("The top member must belong to the top group")
+        if len(bottom_members) != self.top_degree:
+            raise ValueError(
+                f"Expected {self.top_degree} bottom members (provided: {len(bottom_members)})"
+            )
+        if any(member not in self.bottom for member in bottom_members):
+            raise ValueError("All bottom members must belong to the bottom group")
+
+        return GroupMember(
+            [
+                top_member.apply(row) * self.bottom_degree + bottom_members[row].apply(col)
+                for row in range(self.top_degree)
+                for col in range(self.bottom_degree)
+            ]
+        )
+
+
 ################################################################################
 # "simple" named groups
 

--- a/src/qldpc/abstract/groups.py
+++ b/src/qldpc/abstract/groups.py
@@ -246,6 +246,12 @@ class Group:
         new_group._group = group
         return new_group
 
+    def with_natural_lift(self) -> Group:
+        """Copy this group with its natural permutation representation as the lift."""
+        group = Group()
+        group._init_from_group(self, name=self.name, lift=GroupMember.to_matrix)
+        return group
+
     def __contains__(self, member: GroupMember) -> bool:
         return member in self._group
 

--- a/src/qldpc/abstract/groups_test.py
+++ b/src/qldpc/abstract/groups_test.py
@@ -108,6 +108,24 @@ def test_group_equality_and_equivalence() -> None:
     assert not group.equiv("not a group")
 
 
+def test_natural_lift() -> None:
+    """Select the natural permutation representation of a group."""
+    group = abstract.SymmetricGroup(3)
+    natural_group = group.with_natural_lift()
+
+    assert group.lift_dim == group.order == 6
+    assert natural_group.lift_dim == 3
+    assert natural_group != group
+    assert natural_group.equiv(group)
+    assert natural_group.name == group.name
+    assert list(natural_group.generate()) == list(group.generate())
+    assert all(
+        np.array_equal(natural_group.lift(member), member.to_matrix())
+        for member in natural_group.generate()
+    )
+    assert_valid_lifts(natural_group)
+
+
 def test_lifts() -> None:
     """Lift named group elements."""
     assert_valid_lifts(abstract.TrivialGroup())

--- a/src/qldpc/abstract/groups_test.py
+++ b/src/qldpc/abstract/groups_test.py
@@ -222,6 +222,29 @@ def test_group_product() -> None:
     assert np.array_equal(table, abstract.Group.from_table(table).table)
 
 
+def test_group_tensor_product() -> None:
+    """Direct product of groups that preserves the selected factor lifts."""
+    top = abstract.SymmetricGroup(3).with_natural_lift()
+    bottom = abstract.CyclicGroup(5)
+    group = abstract.Group.tensor_product(top, bottom)
+
+    assert group.equiv(abstract.Group.product(top, bottom))
+    assert group.order == 30
+    assert group.lift_dim == 15
+    assert all(
+        np.array_equal(
+            group.lift(top_member @ bottom_member),
+            np.kron(top.lift(top_member), bottom.lift(bottom_member)),
+        )
+        for top_member, bottom_member in itertools.product(top.generate(), bottom.generate())
+    )
+    assert_valid_lifts(group)
+
+    cycle = abstract.CyclicGroup(2)
+    repeated_group = abstract.Group.tensor_product(cycle, repeat=2)
+    assert repeated_group.lift_dim == 4
+
+
 def test_random_symmetric_subset() -> None:
     """Group.random_symmetric_subset generates properly symmetric subsets of the requested size."""
     group = abstract.CyclicGroup(2) * abstract.CyclicGroup(3)

--- a/src/qldpc/abstract/groups_test.py
+++ b/src/qldpc/abstract/groups_test.py
@@ -245,6 +245,58 @@ def test_group_tensor_product() -> None:
     assert repeated_group.lift_dim == 4
 
 
+def test_wreath_product_group() -> None:
+    """Permutational wreath product of top and bottom groups."""
+    top = abstract.SymmetricGroup(3).with_natural_lift()
+    bottom = abstract.CyclicGroup(2)
+    group = abstract.WreathProductGroup(top, bottom)
+
+    assert group.top is top and group.bottom is bottom
+    assert group.top_degree == 3 and group.bottom_degree == 2
+    assert group.order == top.order * bottom.order**group.top_degree == 48
+    assert group.lift_dim == group.top_degree * group.bottom_degree == 6
+
+    top_member = top.generators[0]
+    bottom_identity, bottom_shift = bottom.generate()
+    bottom_members = [bottom_shift, bottom_identity, bottom_shift]
+    member = group.element(top_member, bottom_members)
+    assert member in group
+    assert all(
+        member.apply(row * group.bottom_degree + col)
+        == top_member.apply(row) * group.bottom_degree + bottom_members[row].apply(col)
+        for row in range(group.top_degree)
+        for col in range(group.bottom_degree)
+    )
+    assert np.array_equal(group.lift(member), member.to_matrix())
+    assert_valid_lifts(group)
+
+    direct_product = abstract.Group.tensor_product(top, bottom)
+    direct_member = top_member @ bottom_shift
+    wreath_member = group.element(top_member, [bottom_shift] * group.top_degree)
+    assert np.array_equal(group.lift(wreath_member), direct_product.lift(direct_member))
+
+
+def test_wreath_product_group_errors() -> None:
+    """Reject invalid wreath-product factors and elements."""
+    top = abstract.SymmetricGroup(3)
+    bottom = abstract.CyclicGroup(2)
+    group = abstract.WreathProductGroup(top, bottom)
+
+    with pytest.raises(ValueError, match="top member"):
+        group.element(abstract.CyclicGroup(4).generators[0], [bottom.identity] * 3)
+    with pytest.raises(ValueError, match="Expected 3 bottom members"):
+        group.element(top.identity, [bottom.identity] * 2)
+    with pytest.raises(ValueError, match="bottom group"):
+        group.element(top.identity, [bottom.identity] * 2 + abstract.CyclicGroup(3).generators)
+
+    for factor_a, factor_b in [
+        (abstract.TrivialGroup(), bottom),
+        (bottom, abstract.TrivialGroup()),
+    ]:
+        with pytest.raises(ValueError, match="nonempty"):
+            abstract.WreathProductGroup(factor_a, factor_b)
+
+
 def test_random_symmetric_subset() -> None:
     """Group.random_symmetric_subset generates properly symmetric subsets of the requested size."""
     group = abstract.CyclicGroup(2) * abstract.CyclicGroup(3)

--- a/src/qldpc/codes/quantum_test.py
+++ b/src/qldpc/codes/quantum_test.py
@@ -174,6 +174,46 @@ def test_gala_code_active_orthogonality() -> None:
     assert np.any(code.matrix_x @ code.matrix_z.T)
 
 
+def test_gala_product_group_integration() -> None:
+    """Construct GALA codes from direct- and wreath-product group elements."""
+    top = abstract.SymmetricGroup(3).with_natural_lift()
+    bottom = abstract.CyclicGroup(2)
+    top_f, top_g = top.generators
+    bottom_identity, bottom_shift = bottom.generate()
+
+    direct_product = abstract.Group.tensor_product(top, bottom)
+    direct_ring = abstract.GroupRing(direct_product)
+    direct_generator_f = abstract.RingMember(direct_ring, top_f @ bottom_shift)
+    direct_generator_g = abstract.RingMember(direct_ring, top_g @ bottom_identity)
+    direct_code = codes.GALACode(
+        [direct_generator_f] * 2, [direct_generator_g] * 2, num_active_rows=1
+    )
+
+    wreath_product = abstract.WreathProductGroup(top, bottom)
+    wreath_element_f = wreath_product.element(top_f, [bottom_shift, bottom_identity, bottom_shift])
+    wreath_element_g = wreath_product.element(
+        top_g, [bottom_identity, bottom_shift, bottom_identity]
+    )
+    wreath_ring = abstract.GroupRing(wreath_product)
+    wreath_generator_f = abstract.RingMember(wreath_ring, wreath_element_f)
+    wreath_generator_g = abstract.RingMember(wreath_ring, wreath_element_g)
+    wreath_code = codes.GALACode(
+        [wreath_generator_f] * 2, [wreath_generator_g] * 2, num_active_rows=1
+    )
+
+    assert direct_code.group is direct_product
+    assert direct_code.matrix_x.shape == direct_code.matrix_z.shape == (6, 24)
+    assert direct_code.num_qubits == 24
+    assert direct_code.get_weight() == 4
+    assert not np.any(direct_code.matrix_x @ direct_code.matrix_z.T)
+
+    assert wreath_code.group is wreath_product
+    assert wreath_code.matrix_x.shape == wreath_code.matrix_z.shape == (6, 24)
+    assert wreath_code.num_qubits == 24
+    assert wreath_code.get_weight() == 4
+    assert not np.any(wreath_code.matrix_x @ wreath_code.matrix_z.T)
+
+
 def test_gala_code_errors() -> None:
     """Reject invalid GALA generator data."""
     ring = abstract.GroupRing(abstract.CyclicGroup(3))


### PR DESCRIPTION
## Summary

This PR adds the product-group representations needed to construct GALA codes more faithfully to the paper’s prescription.

The paper defines GALA lifts over direct products $H_k \times C_m$ and semidirect products $H_k \ltimes C_m^k$. This PR adds the corresponding qLDPC abstractions:

- `Group.with_natural_lift()` selects a group’s natural permutation representation. This allows $H_k$ to act on $k$ points instead of using the regular representation of dimension $|H_k|$.

- `Group.tensor_product()` constructs a direct product whose selected lift is the Kronecker product

  $M_H(h) \otimes M_C(c),$

  matching the paper’s direct-product GALA representation.

- `WreathProductGroup` implements the permutational semidirect product

  $H_k \ltimes C_m^k$

  with the paper’s action

  $(i,j) \mapsto \bigl(h(i),c_i(j)\bigr).$

- `WreathProductGroup` is exported through `qldpc.abstract` for public use.

Together, these additions let users construct `GALACode` generators directly from the natural direct- and semidirect-product group elements used by the paper, without manually supplying a custom matrix lift.

## Testing

The new tests verify:

- Natural lifts preserve the abstract group while selecting the intended permutation dimension.
- Tensor-product groups are equivalent to the corresponding abstract direct products and lift elements through Kronecker products.
- Wreath-product elements act correctly on block and within-block coordinates.
- The diagonal subgroup of a wreath product reproduces the corresponding direct-product lift.
- Invalid wreath-product elements and factors are rejected.
- Direct- and semidirect-product group-ring elements integrate with `GALACode` and produce valid commuting CSS checks.

This work was done in collaboration with Codex