### PR TITLE
Normalize member degree in Group.lift, add Group.degree

### DIFF
--- a/src/qldpc/abstract/groups.py
+++ b/src/qldpc/abstract/groups.py
@@ -739,6 +739,10 @@ class WreathProductGroup(Group):
         if any(member not in self.bottom for member in bottom_members):
             raise ValueError("All bottom members must belong to the bottom group")
 
+        # pad members to their full degree, since apply below indexes over every point
+        top_member = self.top._pad(top_member)
+        bottom_members = tuple(self.bottom._pad(member) for member in bottom_members)
+
         return GroupMember(
             [
                 top_member.apply(row) * self.bottom_degree + bottom_members[row].apply(col)

--- a/src/qldpc/abstract/groups.py
+++ b/src/qldpc/abstract/groups.py
@@ -257,7 +257,23 @@ class Group:
         return group
 
     def __contains__(self, member: GroupMember) -> bool:
-        return member in self._group
+        return self._pad(member) in self._group
+
+    def _pad(self, member: GroupMember) -> GroupMember:
+        """Pad a member to this group's full degree.
+
+        A permutation on n points is stored as the list of images [f(0), ..., f(n-1)].  SymPy
+        (which backs GroupMember) records only up to the largest moved point: any points fixed at
+        the tail are omitted, so a member built directly (e.g. from cycle notation) can have a
+        shorter image list than this group's degree.  For example, the permutation swapping 0 and 1
+        in the symmetric group on 3 points (degree 3) is stored as [1, 0] rather than [1, 0, 2].
+
+        Member-keyed operations (containment, indexing, custom lifts) assume a full-degree member,
+        so re-append the omitted fixed tail points before use.
+        """
+        if member.size < self.degree:
+            return GroupMember(member, size=self.degree)
+        return member
 
     @property
     def order(self) -> int:
@@ -308,7 +324,7 @@ class Group:
 
     def index(self, member: GroupMember) -> int:
         """The index of a GroupMember in this group."""
-        index = self._members.get(member)
+        index = self._members.get(self._pad(member))
         if not isinstance(index, int):
             raise TypeError(f"Member {member} not in group {self}")
         return index
@@ -458,12 +474,7 @@ class Group:
         if self._lift is None:
             return self.regular_lift(member, right=right)
         if not right or self.is_commutative:
-            # SymPy drops trailing fixed points, so a directly-constructed member (e.g. from cycle
-            # notation) may have array_form shorter than this group's degree.  Custom lifts assume a
-            # full-degree member, so pad the member with its fixed tail points before lifting.
-            if member.size < self.degree:
-                member = GroupMember(member, size=self.degree)
-            return self._lift(member)
+            return self._lift(self._pad(member))
         raise ValueError(
             "Anti-representations for non-commutative groups with custom lifts are not supported"
         )

--- a/src/qldpc/abstract/groups.py
+++ b/src/qldpc/abstract/groups.py
@@ -257,23 +257,7 @@ class Group:
         return group
 
     def __contains__(self, member: GroupMember) -> bool:
-        return self._pad(member) in self._group
-
-    def _pad(self, member: GroupMember) -> GroupMember:
-        """Pad a member to this group's full degree.
-
-        A permutation on n points is stored as the list of images [f(0), ..., f(n-1)].  SymPy
-        (which backs GroupMember) records only up to the largest moved point: any points fixed at
-        the tail are omitted, so a member built directly (e.g. from cycle notation) can have a
-        shorter image list than this group's degree.  For example, the permutation swapping 0 and 1
-        in the symmetric group on 3 points (degree 3) is stored as [1, 0] rather than [1, 0, 2].
-
-        Member-keyed operations (containment, indexing, custom lifts) assume a full-degree member,
-        so re-append the omitted fixed tail points before use.
-        """
-        if member.size < self.degree:
-            return GroupMember(member, size=self.degree)
-        return member
+        return member in self._group
 
     @property
     def order(self) -> int:
@@ -324,7 +308,7 @@ class Group:
 
     def index(self, member: GroupMember) -> int:
         """The index of a GroupMember in this group."""
-        index = self._members.get(self._pad(member))
+        index = self._members.get(member)
         if not isinstance(index, int):
             raise TypeError(f"Member {member} not in group {self}")
         return index
@@ -474,7 +458,13 @@ class Group:
         if self._lift is None:
             return self.regular_lift(member, right=right)
         if not right or self.is_commutative:
-            return self._lift(self._pad(member))
+            # SymPy stores a permutation only up to its largest moved point, so a member built
+            # directly (e.g. from cycle notation) can have an image list shorter than this group's
+            # degree.  Custom lifts read the full image list, so re-append the omitted fixed tail
+            # points before lifting.
+            if member.size < self.degree:
+                member = GroupMember(member, size=self.degree)
+            return self._lift(member)
         raise ValueError(
             "Anti-representations for non-commutative groups with custom lifts are not supported"
         )
@@ -738,10 +728,6 @@ class WreathProductGroup(Group):
             )
         if any(member not in self.bottom for member in bottom_members):
             raise ValueError("All bottom members must belong to the bottom group")
-
-        # pad members to their full degree, since apply below indexes over every point
-        top_member = self.top._pad(top_member)
-        bottom_members = tuple(self.bottom._pad(member) for member in bottom_members)
 
         return GroupMember(
             [

--- a/src/qldpc/abstract/groups.py
+++ b/src/qldpc/abstract/groups.py
@@ -265,6 +265,11 @@ class Group:
         return int(self._group.order())
 
     @property
+    def degree(self) -> int:
+        """Number of points that this group's permutation representation acts on."""
+        return self._group.degree
+
+    @property
     def is_commutative(self) -> bool:
         """Is this group commutative (abelian)?"""
         return isinstance(self, AbelianGroup) or self._group.is_abelian
@@ -332,7 +337,7 @@ class Group:
         """
         groups = groups * repeat
         product = Group.product(*groups)
-        degrees = [group.to_sympy().degree for group in groups]
+        degrees = [group.degree for group in groups]
 
         def lift(member: GroupMember) -> npt.NDArray[np.int_]:
             matrices = []
@@ -453,6 +458,11 @@ class Group:
         if self._lift is None:
             return self.regular_lift(member, right=right)
         if not right or self.is_commutative:
+            # SymPy drops trailing fixed points, so a directly-constructed member (e.g. from cycle
+            # notation) may have array_form shorter than this group's degree.  Custom lifts assume a
+            # full-degree member, so pad the member with its fixed tail points before lifting.
+            if member.size < self.degree:
+                member = GroupMember(member.array_form + list(range(member.size, self.degree)))
             return self._lift(member)
         raise ValueError(
             "Anti-representations for non-commutative groups with custom lifts are not supported"
@@ -673,8 +683,8 @@ class WreathProductGroup(Group):
     def __init__(self, top: Group, bottom: Group) -> None:
         self.top = top
         self.bottom = bottom
-        self.top_degree = top.to_sympy().degree
-        self.bottom_degree = bottom.to_sympy().degree
+        self.top_degree = top.degree
+        self.bottom_degree = bottom.degree
         if not self.top_degree or not self.bottom_degree:
             raise ValueError("Wreath-product groups must act on nonempty sets")
 

--- a/src/qldpc/abstract/groups.py
+++ b/src/qldpc/abstract/groups.py
@@ -462,7 +462,7 @@ class Group:
             # notation) may have array_form shorter than this group's degree.  Custom lifts assume a
             # full-degree member, so pad the member with its fixed tail points before lifting.
             if member.size < self.degree:
-                member = GroupMember(member.array_form + list(range(member.size, self.degree)))
+                member = GroupMember(member, size=self.degree)
             return self._lift(member)
         raise ValueError(
             "Anti-representations for non-commutative groups with custom lifts are not supported"

--- a/src/qldpc/abstract/groups_test.py
+++ b/src/qldpc/abstract/groups_test.py
@@ -307,6 +307,12 @@ def test_wreath_product_group() -> None:
     assert np.array_equal(group.lift(member), member.to_matrix())
     assert_valid_lifts(group)
 
+    # element accepts members whose array_form drops trailing fixed points (e.g. the identity)
+    truncated_top = abstract.GroupMember(top_member.cyclic_form)
+    truncated_bottom = [abstract.GroupMember(bottom_member.cyclic_form) for bottom_member in bottom_members]
+    assert min(bottom_member.size for bottom_member in truncated_bottom) < group.bottom_degree
+    assert group.element(truncated_top, truncated_bottom) == member
+
     direct_product = abstract.Group.tensor_product(top, bottom)
     direct_member = top_member @ bottom_shift
     wreath_member = group.element(top_member, [bottom_shift] * group.top_degree)

--- a/src/qldpc/abstract/groups_test.py
+++ b/src/qldpc/abstract/groups_test.py
@@ -210,8 +210,8 @@ def test_lift_truncated_member() -> None:
     """Custom lifts accept members whose array_form omits trailing fixed points.
 
     SymPy truncates trailing fixed points, so a directly-constructed member (e.g. from cycle
-    notation) can have a shorter array_form than the group's degree.  Member-keyed operations
-    (containment, indexing, custom lifts) pad such members up to the group degree before use.
+    notation) can have a shorter array_form than the group's degree.  Group.lift pads such members
+    up to the group degree before dispatching to a custom lift.
     """
     # a from_table group with an integer_lift exercises the identity-keyed custom lift, alongside
     # the to_matrix-based natural and wreath lifts and the Kronecker-product tensor lift
@@ -235,9 +235,6 @@ def test_lift_truncated_member() -> None:
             truncated = abstract.GroupMember(member.cyclic_form)
             truncated_members += truncated.size < degree
             assert np.array_equal(group.lift(truncated), group.lift(member))
-            # containment and indexing also accept the truncated member
-            assert truncated in group
-            assert group.index(truncated) == group.index(member)
         # the group actually has members whose array_form is shorter than its degree
         assert truncated_members
 
@@ -306,12 +303,6 @@ def test_wreath_product_group() -> None:
     )
     assert np.array_equal(group.lift(member), member.to_matrix())
     assert_valid_lifts(group)
-
-    # element accepts members whose array_form drops trailing fixed points (e.g. the identity)
-    truncated_top = abstract.GroupMember(top_member.cyclic_form)
-    truncated_bottom = [abstract.GroupMember(bottom_member.cyclic_form) for bottom_member in bottom_members]
-    assert min(bottom_member.size for bottom_member in truncated_bottom) < group.bottom_degree
-    assert group.element(truncated_top, truncated_bottom) == member
 
     direct_product = abstract.Group.tensor_product(top, bottom)
     direct_member = top_member @ bottom_shift

--- a/src/qldpc/abstract/groups_test.py
+++ b/src/qldpc/abstract/groups_test.py
@@ -47,6 +47,7 @@ def test_permutation_group(pytestconfig: pytest.Config) -> None:
     group = abstract.Group(*gens)
     assert all(perm in group for perm in gens)
     assert len(group.generators) == 2
+    assert group.order == group.degree == 3
     assert group.random() in group
     assert group.random(seed=0) == group.random(seed=0)
     assert group.to_sympy() == group._group
@@ -203,6 +204,39 @@ def assert_valid_lifts(group: abstract.Group) -> None:
             )
             for aa, bb in itertools.product(group_members, repeat=2)
         )
+
+
+def test_lift_truncated_member() -> None:
+    """Custom lifts accept members whose array_form omits trailing fixed points.
+
+    SymPy truncates trailing fixed points, so a directly-constructed member (e.g. from cycle
+    notation) can have a shorter array_form than the group's degree.  Group.lift pads such members
+    up to the group degree before dispatching to a custom lift.
+    """
+    # a from_table group with an integer_lift exercises the identity-keyed custom lift, alongside
+    # the to_matrix-based natural and wreath lifts and the Kronecker-product tensor lift
+    table = [[0, 1, 2], [1, 2, 0], [2, 0, 1]]
+    table_group = abstract.Group.from_table(
+        table, integer_lift=lambda index: np.roll(np.eye(3, dtype=int), index, axis=0)
+    )
+    groups = [
+        abstract.SymmetricGroup(3).with_natural_lift(),
+        abstract.Group.tensor_product(
+            abstract.SymmetricGroup(3).with_natural_lift(), abstract.CyclicGroup(5)
+        ),
+        abstract.WreathProductGroup(abstract.SymmetricGroup(3), abstract.CyclicGroup(2)),
+        table_group,
+    ]
+    for group in groups:
+        degree = group.degree
+        truncated_members = 0
+        for member in group.generate():
+            # rebuild from cyclic form, which drops trailing fixed points as SymPy does
+            truncated = abstract.GroupMember(member.cyclic_form)
+            truncated_members += truncated.size < degree
+            assert np.array_equal(group.lift(truncated), group.lift(member))
+        # the group actually has members whose array_form is shorter than its degree
+        assert truncated_members
 
 
 def test_group_product() -> None:

--- a/src/qldpc/abstract/groups_test.py
+++ b/src/qldpc/abstract/groups_test.py
@@ -210,8 +210,8 @@ def test_lift_truncated_member() -> None:
     """Custom lifts accept members whose array_form omits trailing fixed points.
 
     SymPy truncates trailing fixed points, so a directly-constructed member (e.g. from cycle
-    notation) can have a shorter array_form than the group's degree.  Group.lift pads such members
-    up to the group degree before dispatching to a custom lift.
+    notation) can have a shorter array_form than the group's degree.  Member-keyed operations
+    (containment, indexing, custom lifts) pad such members up to the group degree before use.
     """
     # a from_table group with an integer_lift exercises the identity-keyed custom lift, alongside
     # the to_matrix-based natural and wreath lifts and the Kronecker-product tensor lift
@@ -235,6 +235,9 @@ def test_lift_truncated_member() -> None:
             truncated = abstract.GroupMember(member.cyclic_form)
             truncated_members += truncated.size < degree
             assert np.array_equal(group.lift(truncated), group.lift(member))
+            # containment and indexing also accept the truncated member
+            assert truncated in group
+            assert group.index(truncated) == group.index(member)
         # the group actually has members whose array_form is shorter than its degree
         assert truncated_members
 


### PR DESCRIPTION
AI-assisted summary:

Make custom group lifts robust to members whose stored image list is shorter than the group's degree, and add a `Group.degree` property.  SymPy (which backs `GroupMember`) stores a permutation only up to its largest moved point, so a member built directly, for example from cycle notation, can drop trailing fixed points and end up with a shorter image list than the group acts on.  Custom lifts read the full image list, so such a member previously either crashed (tensor product), silently produced a wrong-size matrix (natural and wreath lifts), or raised a `KeyError` (table-based lift).  `Group.lift` now re-appends the omitted fixed tail points, padding the member up to the group's degree before dispatching to the custom lift; this is a no-op for full-degree members, so it changes nothing for normal usage.

The fix is deliberately confined to `Group.lift`, where padding is an internal computation detail that never affects member identity or equality.  Containment and indexing are left strict: a short member is still reported as not in the group, matching SymPy's size-sensitive equality.  This is intentional.  No normal workflow ever produces a short member (every member from `identity`, `generators`, `generate`, and the `@` tensor-product operator is full-degree), so the only case affected is a hand-constructed member, and making containment/indexing lenient would be a leaky, higher-maintenance change that could not be made fully consistent without overriding `GroupMember` equality and hashing.

This PR also adds `Group.degree` (mirroring `Group.order`) and uses it in place of the existing `group.to_sympy().degree` calls, plus a test that lifts short members across the natural, tensor-product, wreath, and table-based lifts.