### PR TITLE
Fix modular test coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ ini_options.filterwarnings = [
 
 [tool.coverage]
 run.include = [ "./*" ]
+run.parallel = true
 report.fail_under = 100
 report.exclude_lines = [ "if TYPE_CHECKING:", "pragma: no cover" ]
 report.skip_covered = true

--- a/src/qldpc/abstract/groups_test.py
+++ b/src/qldpc/abstract/groups_test.py
@@ -93,6 +93,10 @@ def test_trivial_group() -> None:
     assert group.equiv(abstract.Group.from_generating_mats())
     assert str(group) == "TrivialGroup"
 
+    # to_ring_array is a defunct alias that only raises, directing callers to RingArray.build
+    with pytest.raises(ValueError, match="DEFUNCT"):
+        abstract.TrivialGroup.to_ring_array([[1]])
+
 
 def test_group_equality_and_equivalence() -> None:
     """``==`` requires a matching representation; ``equiv`` compares underlying groups only."""

--- a/src/qldpc/codes/quantum_test.py
+++ b/src/qldpc/codes/quantum_test.py
@@ -1017,6 +1017,7 @@ def test_reed_muller_css_codes() -> None:
         ((2, 10), (1024, 912, 8)),
     ]:
         code = codes.QuantumReedMullerCode(order, size)
+        assert (code.order, code.size) == (order, size)
         assert code.get_code_params() == params
         assert code.get_distance() == params[2]
         assert code.get_distance(Pauli.X) == params[2]


### PR DESCRIPTION
### AI-generated summary

The coverage check combines each file's results into one report, but the option that lets those results be combined (`run.parallel`) was never enabled — so the report only reflected the last file to run, and the check passed without looking at the rest of the repo. Turning on `run.parallel = true` fixes that, and it exposed two untested lines along the way — the `QuantumReedMullerCode.order`/`size` getters and the `TrivialGroup.to_ring_array` error — which this covers with a test each.