### PR TITLE
objects.py: fix group-algebra tensor products and qudit-operator parsing

### DIFF
--- a/src/qldpc/objects.py
+++ b/src/qldpc/objects.py
@@ -340,11 +340,11 @@ class CayleyComplex:
             # add all edges adjacent to this node
             for aa in subset_a:
                 aa_gg = aa * gg
-                graph.add_edge(gg, aa_gg)
+                graph.add_edge(gg, aa_gg, type="L")  # "L" for left-acting
                 new_nodes.add(aa_gg)
             for bb in subset_b:
                 gg_bb = gg * bb
-                graph.add_edge(gg, gg_bb)
+                graph.add_edge(gg, gg_bb, type="R")  # "R" for right-acting
                 new_nodes.add(gg_bb)
 
             nodes_to_add |= new_nodes - old_nodes

--- a/src/qldpc/objects.py
+++ b/src/qldpc/objects.py
@@ -574,9 +574,7 @@ class ChainComplex:
 
         if chain_a.ring is None:
             return ChainComplex([op.view(chain_field) for op in matrices], skip_validation=True)
-        ops = []
-        for matrix in matrices:
-            op = matrix.view(abstract.RingArray)
-            op._ring = chain_a.ring
-            ops.append(op)
+        # structurally-zero blocks are integer-valued, so rebuild each operator through
+        # RingArray.build to coerce every entry into a ring member of chain_a.ring
+        ops = [abstract.RingArray.build(matrix, chain_a.ring) for matrix in matrices]
         return ChainComplex(ops, skip_validation=True)

--- a/src/qldpc/objects.py
+++ b/src/qldpc/objects.py
@@ -57,7 +57,7 @@ class Pauli(enum.Enum):
         if self is Pauli.Z:
             return Pauli.X
         raise ValueError(
-            f"Pauli.dual_xz only converts between Pauli.X and Pauli.Z (provided: {self})"
+            f"Pauli.swap_xz only converts between Pauli.X and Pauli.Z (provided: {self})"
         )
 
     def __str__(self) -> str:
@@ -144,10 +144,10 @@ class QuditPauli:
             raise ValueError(invalid_op)
 
         for factor in factors:
-            pauli = factor[0]
+            pauli = factor[:1]
             val_str = factor[2:-1]
             _factor = f"{pauli}({val_str})"
-            if pauli not in "XYZ" or not val_str.isnumeric() or factor != _factor:
+            if pauli not in "XYZ" or not val_str.isdecimal() or factor != _factor:
                 raise ValueError(invalid_op)
 
             val = int(val_str)
@@ -435,7 +435,7 @@ class ChainComplex:
             self._validate_ops()
 
     def _validate_ops(self) -> None:
-        """Validate the consistency of this the boundary operators in this chain complex."""
+        """Validate the consistency of the boundary operators in this chain complex."""
         for op_a, op_b in zip(self.ops, self.ops[1:]):
             if op_a.shape[1] != op_b.shape[0] or np.any(op_a @ op_b):
                 raise ValueError(

--- a/src/qldpc/objects.py
+++ b/src/qldpc/objects.py
@@ -172,9 +172,6 @@ class Node:
     index: int
     is_data: bool = True
 
-    def __hash__(self) -> int:
-        return hash((self.index, self.is_data))
-
     def __lt__(self, other: Node) -> bool:
         if self.is_data == other.is_data:
             return self.index < other.index
@@ -267,9 +264,6 @@ class CayleyComplex:
     subset_b: set[abstract.GroupMember]
     bipartite: bool
 
-    # geometric data
-    _graph: nx.Graph | None = None
-
     def __init__(
         self,
         subset_a: Collection[abstract.GroupMember],
@@ -346,11 +340,11 @@ class CayleyComplex:
             # add all edges adjacent to this node
             for aa in subset_a:
                 aa_gg = aa * gg
-                graph.add_edge(gg, aa_gg, type="L")  # "L" for left-acting
+                graph.add_edge(gg, aa_gg)
                 new_nodes.add(aa_gg)
             for bb in subset_b:
                 gg_bb = gg * bb
-                graph.add_edge(gg, gg_bb, type="R")  # "R" for right-acting
+                graph.add_edge(gg, gg_bb)
                 new_nodes.add(gg_bb)
 
             nodes_to_add |= new_nodes - old_nodes
@@ -396,8 +390,7 @@ class ChainComplex:
     _field: type[galois.FieldArray]
     _ops: tuple[npt.NDArray[np.int_] | abstract.RingArray, ...]
 
-    # if boundary operators are defined over a group algebra, keep track of the base group and ring
-    _group: abstract.Group | None
+    # if boundary operators are defined over a group algebra, keep track of the base ring
     _ring: abstract.GroupRing | None
 
     def __init__(

--- a/src/qldpc/objects.py
+++ b/src/qldpc/objects.py
@@ -574,7 +574,6 @@ class ChainComplex:
 
         if chain_a.ring is None:
             return ChainComplex([op.view(chain_field) for op in matrices], skip_validation=True)
-        # structurally-zero blocks are integer-valued, so rebuild each operator through
-        # RingArray.build to coerce every entry into a ring member of chain_a.ring
+        # rebuild each operator through RingArray.build to coerce every entry into a ring member
         ops = [abstract.RingArray.build(matrix, chain_a.ring) for matrix in matrices]
         return ChainComplex(ops, skip_validation=True)

--- a/src/qldpc/objects_test.py
+++ b/src/qldpc/objects_test.py
@@ -146,6 +146,7 @@ def test_chain_complex(field: int = 3) -> None:
     ring_chain = objects.ChainComplex.tensor_product(ring_chain, cyclic_matrix)
     ring_chain._validate_ops()
     for ring_op in ring_chain.ops:
+        assert isinstance(ring_op, abstract.RingArray)
         ring_op.lift()
 
     # invalid chain complex constructions

--- a/src/qldpc/objects_test.py
+++ b/src/qldpc/objects_test.py
@@ -146,6 +146,7 @@ def test_chain_complex(field: int = 3) -> None:
     ring_chain = objects.ChainComplex.tensor_product(ring_chain, cyclic_matrix)
     ring_chain._validate_ops()
     for ring_op in ring_chain.ops:
+        # every op of a ring-valued chain is a RingArray; assert narrows the union type for .lift()
         assert isinstance(ring_op, abstract.RingArray)
         ring_op.lift()
 

--- a/src/qldpc/objects_test.py
+++ b/src/qldpc/objects_test.py
@@ -137,6 +137,17 @@ def test_chain_complex(field: int = 3) -> None:
     assert not np.any(two_chain.op(0))
     assert not np.any(two_chain.op(two_chain.num_links + 1))
 
+    # tensor products over a nontrivial commutative group algebra: once the total complex has three
+    # or more links, some "sector" blocks of a boundary operator are structurally zero, and every
+    # operator must remain a well-formed RingArray whose entries can be lifted to matrices
+    cyclic_ring = abstract.GroupRing(abstract.CyclicGroup(3), field)
+    cyclic_matrix = abstract.RingArray.build(matrix, cyclic_ring)
+    ring_chain = objects.ChainComplex.tensor_product(cyclic_matrix, cyclic_matrix)
+    ring_chain = objects.ChainComplex.tensor_product(ring_chain, cyclic_matrix)
+    ring_chain._validate_ops()
+    for ring_op in ring_chain.ops:
+        ring_op.lift()
+
     # invalid chain complex constructions
     with pytest.raises(ValueError, match="inconsistent operator types"):
         objects.ChainComplex([matrix, abstract.RingArray.build([[0]])])

--- a/src/qldpc/objects_test.py
+++ b/src/qldpc/objects_test.py
@@ -56,7 +56,7 @@ def test_qudit_operator() -> None:
     assert -objects.QuditPauli((0, 1)) == objects.QuditPauli((0, -1))
     for op in ["I", "Y(1)", "X(1)*Z(2)"]:
         assert str(objects.QuditPauli.from_string(op)) == op
-    for op in ["a*b*c", "a(1)"]:
+    for op in ["a*b*c", "a(1)", "*", "X(1)*", "", "X(²)"]:
         with pytest.raises(ValueError, match="Invalid qudit operator"):
             objects.QuditPauli.from_string(op)
 

--- a/src/qldpc/objects_test.py
+++ b/src/qldpc/objects_test.py
@@ -137,9 +137,9 @@ def test_chain_complex(field: int = 3) -> None:
     assert not np.any(two_chain.op(0))
     assert not np.any(two_chain.op(two_chain.num_links + 1))
 
-    # tensor products over a nontrivial commutative group algebra: once the total complex has three
-    # or more links, some "sector" blocks of a boundary operator are structurally zero, and every
-    # operator must remain a well-formed RingArray whose entries can be lifted to matrices
+    # a tensor product over a nontrivial commutative group algebra must yield boundary operators
+    # whose entries are all ring members (and can therefore be lifted to matrices), including the
+    # three-or-more-link case where some operator blocks are entirely zero
     cyclic_ring = abstract.GroupRing(abstract.CyclicGroup(3), field)
     cyclic_matrix = abstract.RingArray.build(matrix, cyclic_ring)
     ring_chain = objects.ChainComplex.tensor_product(cyclic_matrix, cyclic_matrix)


### PR DESCRIPTION
### AI-assisted summary

Bug fix. `ChainComplex.tensor_product` over a group algebra built boundary operators whose all-zero blocks were plain integers instead of ring elements. The result still passed the chain-complex check, but any complex with three or more links crashed when its operators were later lifted to matrices (`lift`, `transpose`, and so on). The code families don't reach this today -- they use the finite-field path -- but the method is public, so it is a real latent bug. Each operator is now rebuilt so every entry is a ring element, and a group-algebra test lifts every operator.

Parsing. `QuditPauli.from_string` now raises its documented "Invalid qudit operator" error for all malformed input. Previously an empty factor (such as "*" or "") raised `IndexError`, and non-decimal digits raised a different, confusing error.

Cleanup. Corrected the `swap_xz` error message (it named a method that does not exist), fixed a docstring typo, and removed dead code: an unused attribute on each of `ChainComplex` and `CayleyComplex`, unused edge labels in the Cayley graph, and a redundant `Node.__hash__`.