### PR TITLE
fix GAP field-element encoding over extension fields + other minor fixes

### DIFF
--- a/src/qldpc/cache.py
+++ b/src/qldpc/cache.py
@@ -41,7 +41,11 @@ def get_disk_cache_path(
 def get_disk_cache(
     cache_name: str, *, cache_dir: pathlib.Path | str | None = None
 ) -> diskcache.Cache:
-    """Retrieve a dictionary-like cache object."""
+    """Retrieve a dictionary-like cache object.
+
+    Under pytest this returns a fresh in-memory ``dict`` instead of an on-disk cache, so tests never
+    read or write the persistent cache.
+    """
     if running_with_pytest():
         return {}
     return diskcache.Cache(get_disk_cache_path(cache_name, cache_dir=cache_dir))
@@ -53,7 +57,11 @@ def use_disk_cache(
     cache_dir: pathlib.Path | str | None = None,
     key_func: Callable[..., Hashable] | None = None,
 ) -> Callable[[Callable[Params, Any]], Callable[Params, Any]]:
-    """Decorator to cache results to disk."""
+    """Decorator to cache results to disk.
+
+    Under pytest this is a no-op: it returns the undecorated function, so results are never cached
+    during tests.
+    """
 
     def decorator(function: Callable[Params, Any]) -> Callable[Params, Any]:
         if running_with_pytest():

--- a/src/qldpc/cache.py
+++ b/src/qldpc/cache.py
@@ -43,8 +43,8 @@ def get_disk_cache(
 ) -> diskcache.Cache:
     """Retrieve a dictionary-like cache object.
 
-    Under pytest this returns a fresh in-memory ``dict`` instead of an on-disk cache, so tests never
-    read or write the persistent cache.
+    Under pytest this function returns a fresh in-memory ``dict`` instead of an on-disk cache, so
+    tests never read or write the persistent cache.
     """
     if running_with_pytest():
         return {}
@@ -59,8 +59,8 @@ def use_disk_cache(
 ) -> Callable[[Callable[Params, Any]], Callable[Params, Any]]:
     """Decorator to cache results to disk.
 
-    Under pytest this is a no-op: it returns the undecorated function, so results are never cached
-    during tests.
+    Under pytest this decorator is a no-op: it returns the undecorated function, so results are
+    never cached during tests.
     """
 
     def decorator(function: Callable[Params, Any]) -> Callable[Params, Any]:

--- a/src/qldpc/cache.py
+++ b/src/qldpc/cache.py
@@ -41,11 +41,7 @@ def get_disk_cache_path(
 def get_disk_cache(
     cache_name: str, *, cache_dir: pathlib.Path | str | None = None
 ) -> diskcache.Cache:
-    """Retrieve a dictionary-like cache object.
-
-    Under pytest this function returns a fresh in-memory ``dict`` instead of an on-disk cache, so
-    tests never read or write the persistent cache.
-    """
+    """Retrieve a dictionary-like cache object."""
     if running_with_pytest():
         return {}
     return diskcache.Cache(get_disk_cache_path(cache_name, cache_dir=cache_dir))
@@ -57,11 +53,7 @@ def use_disk_cache(
     cache_dir: pathlib.Path | str | None = None,
     key_func: Callable[..., Hashable] | None = None,
 ) -> Callable[[Callable[Params, Any]], Callable[Params, Any]]:
-    """Decorator to cache results to disk.
-
-    Under pytest this decorator is a no-op: it returns the undecorated function, so results are
-    never cached during tests.
-    """
+    """Decorator to cache results to disk."""
 
     def decorator(function: Callable[Params, Any]) -> Callable[Params, Any]:
         if running_with_pytest():

--- a/src/qldpc/external/codes.py
+++ b/src/qldpc/external/codes.py
@@ -39,8 +39,7 @@ def get_classical_code(code: str) -> tuple[list[list[int]], int]:
     """Retrieve a classical code from GAP.
 
     Runs GAP in a subprocess.  Requires the GAP GUAVA package
-    (https://www.gap-system.org/Packages/guava.html); installing a missing package may prompt and
-    run ``git clone``.
+    (https://www.gap-system.org/Packages/guava.html).
     """
     qldpc.external.gap.require_package("GUAVA")
 
@@ -183,8 +182,7 @@ def get_distance_bound(
     """Estimate the distance of a quantum code using GAP's QDistRnd package.
 
     Runs GAP in a subprocess.  The estimate is a randomized upper bound (QDistRnd samples random
-    codewords).  Requires the GAP GUAVA and QDistRnd packages; installing a missing package may
-    prompt and run ``git clone``.
+    codewords).  Requires the GAP GUAVA and QDistRnd packages.
 
     If given a CSSCode, estimate the Z-distance (minimum weight of a Z-type logical operator).
     See https://qec-pages.github.io/QDistRnd/doc/chap4.html.

--- a/src/qldpc/external/codes.py
+++ b/src/qldpc/external/codes.py
@@ -38,8 +38,9 @@ import qldpc.external.gap
 def get_classical_code(code: str) -> tuple[list[list[int]], int]:
     """Retrieve a classical code from GAP.
 
-    Requires the GAP GUAVA package (https://www.gap-system.org/Packages/guava.html); installing a
-    missing package may prompt and run ``git clone``, and this runs GAP in a subprocess.
+    Runs GAP in a subprocess.  Requires the GAP GUAVA package
+    (https://www.gap-system.org/Packages/guava.html); installing a missing package may prompt and
+    run ``git clone``.
     """
     qldpc.external.gap.require_package("GUAVA")
 
@@ -146,10 +147,9 @@ def _gap_define_sparse_matrix(
     nonzero_str = ",".join(nonzero_row_str(nonzeros) for nonzeros in nonzero_entries)
 
     # Map each stored galois integer 1..field_order-1 to the matching GAP field element.  A galois
-    # integer f encodes the element's coordinates in the primitive-element basis, so it equals
-    # Z(field_order)^log(f) -- not f*One(F), which over an extension field would collapse to
-    # (f mod p)*One(F).  GAP and galois share the primitive element Z(field_order) (both use Conway
-    # polynomials for the field orders that arise here), so the powers agree.
+    # integer encodes an element's coordinates in the primitive-element basis, so it equals
+    # Z(field_order)^log.  GAP and galois share that primitive element (both use Conway
+    # polynomials), so the powers agree.
     field = galois.GF(field_order)
     field_elements = ",".join(
         f"Z({field_order})^{int(field(value).log())}" for value in range(1, field_order)
@@ -157,13 +157,13 @@ def _gap_define_sparse_matrix(
     commands = [
         f"nz:=[{nonzero_str}];;",
         f"F:=GF({field_order});;",
-        f"elts:=[{field_elements}];;",
+        f"elements:=[{field_elements}];;",
         f"{matrix_var}:=[];",
         "for r in nz do",
         f"  v:=ListWithIdenticalEntries({matrix_width},Zero(F));;",
         f"  for f in [1..{field_order - 1}] do",
         "    for i in r[f] do",
-        "      v[i+1]:=elts[f];;",
+        "      v[i+1]:=elements[f];;",
         "    od;;",
         "  od;;",
         f"  Append({matrix_var},[v]);;",
@@ -182,9 +182,9 @@ def get_distance_bound(
 ) -> int:
     """Estimate the distance of a quantum code using GAP's QDistRnd package.
 
-    The estimate is a randomized upper bound (QDistRnd samples random codewords).  Requires the
-    GAP GUAVA and QDistRnd packages; installing a missing package may prompt and run ``git clone``,
-    and this runs GAP in a subprocess.
+    Runs GAP in a subprocess.  The estimate is a randomized upper bound (QDistRnd samples random
+    codewords).  Requires the GAP GUAVA and QDistRnd packages; installing a missing package may
+    prompt and run ``git clone``.
 
     If given a CSSCode, estimate the Z-distance (minimum weight of a Z-type logical operator).
     See https://qec-pages.github.io/QDistRnd/doc/chap4.html.

--- a/src/qldpc/external/codes.py
+++ b/src/qldpc/external/codes.py
@@ -64,13 +64,14 @@ def get_classical_code(code: str) -> tuple[list[list[int]], int]:
     field: int | None = None
     logarithms = []
     for line in code_str.splitlines():
-        if not line.strip():
+        line = line.strip()
+        if not line:
             continue
 
         if field is None and (match := re.search(r"GF\(([0-9]+(\^[0-9]+)?)\)", line)):
             base, exponent, *_ = (match.group(1) + "^1").split("^")
             field = int(base) ** int(exponent)
-        else:
+        elif line.startswith("["):
             logarithms.append(ast.literal_eval(line))
 
     if field is None:
@@ -97,7 +98,7 @@ def get_quantum_code(code_id: str) -> tuple[list[str], int | None, bool]:
     url = f"https://qecdb.org/codes/{code_id}"
     try:
         lines = urllib.request.urlopen(url, timeout=10).read().decode("utf-8").splitlines()
-    except urllib.error.URLError as exception:
+    except (urllib.error.URLError, TimeoutError) as exception:
         raise RuntimeError(f"Cannot access {url}") from exception
 
     stab_line = next((line for line in lines if "<td>H</td>" in line), None)

--- a/src/qldpc/external/codes.py
+++ b/src/qldpc/external/codes.py
@@ -36,7 +36,11 @@ import qldpc.external.gap
     key_func=lambda code: "".join(code.split()),  # strip whitespace
 )
 def get_classical_code(code: str) -> tuple[list[list[int]], int]:
-    """Retrieve a classical code from GAP."""
+    """Retrieve a classical code from GAP.
+
+    Requires the GAP GUAVA package (https://www.gap-system.org/Packages/guava.html); installing a
+    missing package may prompt and run ``git clone``, and this runs GAP in a subprocess.
+    """
     qldpc.external.gap.require_package("GUAVA")
 
     # Run GAP commands.  Each check-matrix entry is reported as its discrete logarithm base the
@@ -84,6 +88,9 @@ def get_classical_code(code: str) -> tuple[list[list[int]], int]:
 @qldpc.cache.use_disk_cache("qecdb")
 def get_quantum_code(code_id: str) -> tuple[list[str], int | None, bool]:
     """Retrieve a quantum code from qecdb.org.
+
+    Fetches and scrapes the code's HTML page at https://qecdb.org, so this requires network access
+    and is sensitive to that page's layout.
 
     Return the stabilizers of the code, its distance, and whether it's CSS.
     """
@@ -174,11 +181,16 @@ def get_distance_bound(
 ) -> int:
     """Estimate the distance of a quantum code using GAP's QDistRnd package.
 
+    The estimate is a randomized upper bound (QDistRnd samples random codewords).  Requires the
+    GAP GUAVA and QDistRnd packages; installing a missing package may prompt and run ``git clone``,
+    and this runs GAP in a subprocess.
+
     If given a CSSCode, estimate the Z-distance (minimum weight of a Z-type logical operator).
     See https://qec-pages.github.io/QDistRnd/doc/chap4.html.
 
     Note that QDistRnd does not support subsystem codes.  In the case of a CSS code, however, we
     can still compute the Z-distance by promoting all Z-type gauge group generators to stabilizers.
+    ``maxav`` is passed through to QDistRnd as a raw GAP value (default "fail"); see its docs above.
     """
     qldpc.external.gap.require_package("GUAVA")
     qldpc.external.gap.require_package("QDistRnd", "https://github.com/QEC-pages/QDistRnd")

--- a/src/qldpc/external/codes.py
+++ b/src/qldpc/external/codes.py
@@ -38,8 +38,7 @@ import qldpc.external.gap
 def get_classical_code(code: str) -> tuple[list[list[int]], int]:
     """Retrieve a classical code from GAP.
 
-    Runs GAP in a subprocess.  Requires the GAP GUAVA package
-    (https://www.gap-system.org/Packages/guava.html).
+    Requires the GAP GUAVA package (https://www.gap-system.org/Packages/guava.html).
     """
     qldpc.external.gap.require_package("GUAVA")
 
@@ -181,8 +180,8 @@ def get_distance_bound(
 ) -> int:
     """Estimate the distance of a quantum code using GAP's QDistRnd package.
 
-    Runs GAP in a subprocess.  The estimate is a randomized upper bound (QDistRnd samples random
-    codewords).  Requires the GAP GUAVA and QDistRnd packages.
+    The estimate is a randomized upper bound (QDistRnd samples random codewords).  Requires the GAP
+    GUAVA and QDistRnd packages.
 
     If given a CSSCode, estimate the Z-distance (minimum weight of a Z-type logical operator).
     See https://qec-pages.github.io/QDistRnd/doc/chap4.html.

--- a/src/qldpc/external/codes.py
+++ b/src/qldpc/external/codes.py
@@ -19,8 +19,10 @@ from __future__ import annotations
 
 import ast
 import re
-import urllib
+import urllib.error
+import urllib.request
 
+import galois
 import numpy as np
 import numpy.typing as npt
 
@@ -33,23 +35,30 @@ import qldpc.external.gap
     "codes",
     key_func=lambda code: "".join(code.split()),  # strip whitespace
 )
-def get_classical_code(code: str) -> tuple[list[list[int]], int | None]:
+def get_classical_code(code: str) -> tuple[list[list[int]], int]:
     """Retrieve a classical code from GAP."""
     qldpc.external.gap.require_package("GUAVA")
 
-    # run GAP commands
+    # Run GAP commands.  Each check-matrix entry is reported as its discrete logarithm base the
+    # field's primitive root Z(q), or -1 for a zero entry.  GAP's Int() accepts only prime-field
+    # elements, so a discrete logarithm is the field-agnostic way to bring an extension-field
+    # element back; the entry is rebuilt below as primitive_element**log.  This matches galois's
+    # encoding because GAP and galois share the primitive element (both use Conway polynomials).
     commands = [
         'LoadPackage("guava", false);;',
         f"code := {code};;",
         "mat := CheckMat(code);;",
+        "z := PrimitiveRoot(LeftActingDomain(code));;",
         r'Print(LeftActingDomain(code), "\n");;',
-        r'for vec in mat do Print(List(vec, x -> Int(x)), "\n");; od;;',
+        "for vec in mat do",
+        r'  Print(List(vec, function(x) if IsZero(x) then return -1; else return LogFFE(x, z); fi; end), "\n");;',
+        "od;;",
     ]
     code_str = qldpc.external.gap.get_output(*commands)
 
-    # identify base field and retrieve parity checks
+    # identify the base field, then rebuild the parity checks from the reported discrete logarithms
     field: int | None = None
-    checks = []
+    logarithms = []
     for line in code_str.splitlines():
         if not line.strip():
             continue
@@ -58,11 +67,17 @@ def get_classical_code(code: str) -> tuple[list[list[int]], int | None]:
             base, exponent, *_ = (match.group(1) + "^1").split("^")
             field = int(base) ** int(exponent)
         else:
-            checks.append(ast.literal_eval(line))
+            logarithms.append(ast.literal_eval(line))
 
-    if not checks:
+    if field is None:
+        raise ValueError(f"Could not determine the base field of code: {code}")
+    if not logarithms:
         raise ValueError(f"Code has no parity checks: {code}")
 
+    primitive_element = galois.GF(field).primitive_element
+    checks = [
+        [0 if power < 0 else int(primitive_element**power) for power in row] for row in logarithms
+    ]
     return checks, field
 
 
@@ -121,15 +136,26 @@ def _gap_define_sparse_matrix(
         return f"[{','.join(all_field_vals)}]"
 
     nonzero_str = ",".join(nonzero_row_str(nonzeros) for nonzeros in nonzero_entries)
+
+    # Map each stored galois integer 1..field_order-1 to the matching GAP field element.  A galois
+    # integer f encodes the element's coordinates in the primitive-element basis, so it equals
+    # Z(field_order)^log(f) -- not f*One(F), which over an extension field would collapse to
+    # (f mod p)*One(F).  GAP and galois share the primitive element Z(field_order) (both use Conway
+    # polynomials for the field orders that arise here), so the powers agree.
+    field = galois.GF(field_order)
+    field_elements = ",".join(
+        f"Z({field_order})^{int(field(value).log())}" for value in range(1, field_order)
+    )
     commands = [
         f"nz:=[{nonzero_str}];;",
         f"F:=GF({field_order});;",
+        f"elts:=[{field_elements}];;",
         f"{matrix_var}:=[];",
         "for r in nz do",
         f"  v:=ListWithIdenticalEntries({matrix_width},Zero(F));;",
         f"  for f in [1..{field_order - 1}] do",
         "    for i in r[f] do",
-        "      v[i+1]:=f*One(F);;",
+        "      v[i+1]:=elts[f];;",
         "    od;;",
         "  od;;",
         f"  Append({matrix_var},[v]);;",
@@ -188,9 +214,14 @@ def get_distance_bound(
         ]
 
     # Issue: Piped input somehow causes extra terminal output.  Fix: Ignore all but last line.
-    output = qldpc.external.gap.get_output(*commands, use_pipe=True).strip().splitlines()[-1]
+    result_lines = qldpc.external.gap.get_output(*commands, use_pipe=True).strip().splitlines()
+    if not result_lines:
+        raise ValueError(f"QDistRnd returned no output for code:\n{code}")
+    output = result_lines[-1]
 
     # strip whitespace and comments, and interpret the remaining text as the bound
     lines = [line.strip() for line in output.splitlines()]
     bound = "".join([line for line in lines if not line.startswith("#")])
+    if not bound:
+        raise ValueError(f"Could not parse a distance bound from QDistRnd output: {output!r}")
     return int(bound)

--- a/src/qldpc/external/codes.py
+++ b/src/qldpc/external/codes.py
@@ -45,8 +45,8 @@ def get_classical_code(code: str) -> tuple[list[list[int]], int]:
     # Run GAP commands.  Each check-matrix entry is reported as its discrete logarithm base the
     # field's primitive root Z(q), or -1 for a zero entry.  GAP's Int() accepts only prime-field
     # elements, so a discrete logarithm is the field-agnostic way to bring an extension-field
-    # element back; the entry is rebuilt below as primitive_element**log.  This matches galois's
-    # encoding because GAP and galois share the primitive element (both use Conway polynomials).
+    # element back; the entry is rebuilt below as primitive_element**log, which reproduces galois's
+    # own encoding because GAP and galois share the primitive element (both use Conway polynomials).
     commands = [
         'LoadPackage("guava", false);;',
         f"code := {code};;",
@@ -89,8 +89,8 @@ def get_classical_code(code: str) -> tuple[list[list[int]], int]:
 def get_quantum_code(code_id: str) -> tuple[list[str], int | None, bool]:
     """Retrieve a quantum code from qecdb.org.
 
-    Fetches and scrapes the code's HTML page at https://qecdb.org, so this requires network access
-    and is sensitive to that page's layout.
+    This function fetches and scrapes the code's HTML page at https://qecdb.org, so it requires
+    network access and is sensitive to that page's layout.
 
     Return the stabilizers of the code, its distance, and whether it's CSS.
     """

--- a/src/qldpc/external/codes_test.py
+++ b/src/qldpc/external/codes_test.py
@@ -66,8 +66,8 @@ def test_gap_define_sparse_matrix() -> None:
     """Extension-field entries map to primitive-element powers, not integer multiples of One(F)."""
     # over GF(4) the galois integers 1, 2, 3 are Z(4)^0, Z(4)^1, Z(4)^2 -- not 1, 2, 3 copies of One
     commands = " ".join(external.codes._gap_define_sparse_matrix("m", 4, np.array([[0, 1, 2, 3]])))
-    assert "elts:=[Z(4)^0,Z(4)^1,Z(4)^2]" in commands
-    assert "v[i+1]:=elts[f]" in commands
+    assert "elements:=[Z(4)^0,Z(4)^1,Z(4)^2]" in commands
+    assert "v[i+1]:=elements[f]" in commands
 
 
 def get_mock_page(text: str) -> unittest.mock.MagicMock:

--- a/src/qldpc/external/codes_test.py
+++ b/src/qldpc/external/codes_test.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import unittest.mock
 import urllib
 
+import numpy as np
 import pytest
 
 from qldpc import codes, external
@@ -27,21 +28,46 @@ from qldpc import codes, external
 
 def test_get_classical_code() -> None:
     """Retrieve parity check matrix from GAP 4."""
-    # extract parity check and finite field
-    check = [1, 1]
+    # GAP reports each entry as its discrete log base the primitive root (-1 for a zero entry); over
+    # GF(4) the logs 0, 1, 2 rebuild the galois integers 1, 2, 3 and -1 rebuilds a zero.
     with (
         unittest.mock.patch("qldpc.external.gap.is_installed", return_value=True),
-        unittest.mock.patch("qldpc.external.gap.get_output", return_value=f"\n{check}\nGF(3^3)"),
+        unittest.mock.patch(
+            "qldpc.external.gap.get_output", return_value="\nGF(2^2)\n[-1, 0, 1, 2]"
+        ),
     ):
-        assert external.codes.get_classical_code("") == ([check], 27)
+        assert external.codes.get_classical_code("") == ([[0, 1, 2, 3]], 4)
+
+    # over a prime field the log 0 rebuilds the identity
+    with (
+        unittest.mock.patch("qldpc.external.gap.is_installed", return_value=True),
+        unittest.mock.patch("qldpc.external.gap.get_output", return_value="GF(3)\n[0, 0]"),
+    ):
+        assert external.codes.get_classical_code("") == ([[1, 1]], 3)
+
+    # fail to determine the base field
+    with (
+        unittest.mock.patch("qldpc.external.gap.is_installed", return_value=True),
+        unittest.mock.patch("qldpc.external.gap.get_output", return_value="[0, 0]"),
+        pytest.raises(ValueError, match="Could not determine the base field"),
+    ):
+        external.codes.get_classical_code("")
 
     # fail to find parity checks
     with (
         unittest.mock.patch("qldpc.external.gap.is_installed", return_value=True),
-        unittest.mock.patch("qldpc.external.gap.get_output", return_value=r"\nGF(3^3)"),
+        unittest.mock.patch("qldpc.external.gap.get_output", return_value="GF(3^3)"),
         pytest.raises(ValueError, match="Code has no parity checks"),
     ):
         external.codes.get_classical_code("")
+
+
+def test_gap_define_sparse_matrix() -> None:
+    """Extension-field entries map to primitive-element powers, not integer multiples of One(F)."""
+    # over GF(4) the galois integers 1, 2, 3 are Z(4)^0, Z(4)^1, Z(4)^2 -- not 1, 2, 3 copies of One
+    commands = " ".join(external.codes._gap_define_sparse_matrix("m", 4, np.array([[0, 1, 2, 3]])))
+    assert "elts:=[Z(4)^0,Z(4)^1,Z(4)^2]" in commands
+    assert "v[i+1]:=elts[f]" in commands
 
 
 def get_mock_page(text: str) -> unittest.mock.MagicMock:
@@ -86,3 +112,17 @@ def test_distance_bound() -> None:
         with unittest.mock.patch("qldpc.external.gap.get_output", return_value="3"):
             assert external.codes.get_distance_bound(codes.FiveQubitCode()) == 3
             assert external.codes.get_distance_bound(codes.SteaneCode()) == 3
+
+        # QDistRnd produced no output at all
+        with (
+            unittest.mock.patch("qldpc.external.gap.get_output", return_value=""),
+            pytest.raises(ValueError, match="no output"),
+        ):
+            external.codes.get_distance_bound(codes.FiveQubitCode())
+
+        # QDistRnd output has no bound, only a comment line
+        with (
+            unittest.mock.patch("qldpc.external.gap.get_output", return_value="# comment only"),
+            pytest.raises(ValueError, match="Could not parse a distance bound"),
+        ):
+            external.codes.get_distance_bound(codes.FiveQubitCode())

--- a/src/qldpc/external/gap.py
+++ b/src/qldpc/external/gap.py
@@ -75,7 +75,7 @@ def sanitize_commands(commands: Sequence[str]) -> tuple[str, ...]:
 def get_output(*commands: str, use_pipe: bool = False) -> str:
     """Get the output from the given GAP commands.
 
-    When GAP is callable this runs it in a subprocess.  Otherwise it falls back to a manual workflow
+    When GAP is callable, runs it in a subprocess.  Otherwise falls back to a manual workflow
     that prints the commands, copies them to the system clipboard, and reads pasted output from
     standard input (blocking, and raising ``EOFError`` if standard input is closed), caching the
     result to disk.

--- a/src/qldpc/external/gap.py
+++ b/src/qldpc/external/gap.py
@@ -49,8 +49,8 @@ def is_callable() -> bool:
 def is_installed() -> bool:
     """Is GAP 4 installed?
 
-    When GAP is not callable from the command line, this prompts on standard input, so it blocks in
-    a non-interactive context (and raises ``EOFError`` if standard input is closed).
+    When GAP is not callable from the command line, this function prompts on standard input, so it
+    blocks in a non-interactive context (and raises ``EOFError`` if standard input is closed).
     """
     if is_callable():
         return True
@@ -169,8 +169,9 @@ def get_output(*commands: str, use_pipe: bool = False) -> str:
 def require_package(name: str, repo: str | None = None) -> bool:
     """Enforce the installation of a GAP package.
 
-    If the package is missing and GAP is callable, this prompts on standard input and, with the
-    user's consent, installs it by running ``git clone`` into the GAP root's ``pkg`` directory.
+    If the package is missing and GAP is callable, this function prompts on standard input and,
+    with the user's consent, installs it by running ``git clone`` into the GAP root's ``pkg``
+    directory.
 
     Args:
         name: The GAP package name.

--- a/src/qldpc/external/gap.py
+++ b/src/qldpc/external/gap.py
@@ -75,10 +75,10 @@ def sanitize_commands(commands: Sequence[str]) -> tuple[str, ...]:
 def get_output(*commands: str, use_pipe: bool = False) -> str:
     """Get the output from the given GAP commands.
 
-    When GAP is callable, runs it in a subprocess.  Otherwise falls back to a manual workflow
-    that prints the commands, copies them to the system clipboard, and reads pasted output from
-    standard input (blocking, and raising ``EOFError`` if standard input is closed), caching the
-    result to disk.
+    When GAP is callable, this function runs the commands in a subprocess.  Otherwise it falls back
+    to a manual workflow that prints the commands, copies them to the system clipboard, and reads
+    the pasted output from standard input (blocking, and raising ``EOFError`` if standard input is
+    closed), caching the result to disk.
 
     Raises:
         FileNotFoundError: If GAP 4 is not installed.

--- a/src/qldpc/external/gap.py
+++ b/src/qldpc/external/gap.py
@@ -110,11 +110,11 @@ def get_output(*commands: str, use_pipe: bool = False) -> str:
             check=False,
         )
         if result.returncode or result.stderr:
-            raise ValueError(
-                f"Error encountered when running GAP (exit code {result.returncode}):\n"
-                f"{result.stderr}\n\n"
-                f"GAP command:\n{' '.join(commands)}"
-            )
+            parts = [f"Error encountered when running GAP (exit code {result.returncode})"]
+            if result.stderr:
+                parts.append(result.stderr)
+            parts.append(f"GAP command:\n{' '.join(commands)}")
+            raise ValueError("\n\n".join(parts))
         return result.stdout
 
     command = " ".join(commands)

--- a/src/qldpc/external/gap.py
+++ b/src/qldpc/external/gap.py
@@ -1,5 +1,7 @@
 """Module for communicating with the GAP computer algebra system.
 
+See https://www.gap-system.org.
+
 Copyright 2023 The qLDPC Authors and Infleqtion Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,7 +47,11 @@ def is_callable() -> bool:
 
 @functools.cache
 def is_installed() -> bool:
-    """Is GAP 4 installed?"""
+    """Is GAP 4 installed?
+
+    When GAP is not callable from the command line, this prompts on standard input, so it blocks in
+    a non-interactive context (and raises ``EOFError`` if standard input is closed).
+    """
     if is_callable():
         return True
     print("GAP 4 cannot be called from the command line (with 'gap').")
@@ -67,7 +73,17 @@ def sanitize_commands(commands: Sequence[str]) -> tuple[str, ...]:
 
 
 def get_output(*commands: str, use_pipe: bool = False) -> str:
-    """Get the output from the given GAP commands."""
+    """Get the output from the given GAP commands.
+
+    When GAP is callable this runs it in a subprocess.  Otherwise it falls back to a manual workflow
+    that prints the commands, copies them to the system clipboard, and reads pasted output from
+    standard input (blocking, and raising ``EOFError`` if standard input is closed), caching the
+    result to disk.
+
+    Raises:
+        FileNotFoundError: If GAP 4 is not installed.
+        ValueError: If GAP reports an error (a nonzero exit code or output on standard error).
+    """
     if not is_installed():
         raise FileNotFoundError("GAP 4 is required to proceed, but is not installed")
 
@@ -153,13 +169,17 @@ def get_output(*commands: str, use_pipe: bool = False) -> str:
 def require_package(name: str, repo: str | None = None) -> bool:
     """Enforce the installation of a GAP package.
 
+    If the package is missing and GAP is callable, this prompts on standard input and, with the
+    user's consent, installs it by running ``git clone`` into the GAP root's ``pkg`` directory.
+
     Args:
         name: The GAP package name.
         repo: The repository from which to git clone the package, if necessary.
             Defaults to f"https://github.com/gap-packages/{name}" if no repository is provided.
 
     Raises:
-        ValueError: If the package is not installed and an attempt to install it fails.
+        ModuleNotFoundError: If the package is missing and GAP cannot be called to install it.
+        ValueError: If the user declines to install a missing package, or the installation fails.
 
     Returns:
         True if the requirement is satisfied (raises an error otherwise).

--- a/src/qldpc/external/gap.py
+++ b/src/qldpc/external/gap.py
@@ -93,9 +93,10 @@ def get_output(*commands: str, use_pipe: bool = False) -> str:
             text=True,
             check=False,
         )
-        if result.stderr:
+        if result.returncode or result.stderr:
             raise ValueError(
-                f"Error encountered when running GAP:\n{result.stderr}\n\n"
+                f"Error encountered when running GAP (exit code {result.returncode}):\n"
+                f"{result.stderr}\n\n"
                 f"GAP command:\n{' '.join(commands)}"
             )
         return result.stdout
@@ -122,7 +123,6 @@ def get_output(*commands: str, use_pipe: bool = False) -> str:
         )
         return output
 
-    pyperclip.copy(command)
     print("===============================================================================")
     print("NOTE:")
     try:

--- a/src/qldpc/external/gap_test.py
+++ b/src/qldpc/external/gap_test.py
@@ -87,6 +87,14 @@ def test_get_output(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixtu
         ):
             assert external.gap.get_output()
 
+        # GAP is callable, but exits with a nonzero return code (even with empty stderr)
+        with (
+            unittest.mock.patch("qldpc.external.gap.is_callable", return_value=True),
+            unittest.mock.patch("subprocess.run", return_value=get_mock_process(returncode=1)),
+            pytest.raises(ValueError, match="Error encountered when running GAP"),
+        ):
+            external.gap.get_output()
+
         # GAP is callable, and succeeds
         with (
             unittest.mock.patch("qldpc.external.gap.is_callable", return_value=True),

--- a/src/qldpc/external/groups.py
+++ b/src/qldpc/external/groups.py
@@ -1,5 +1,7 @@
 """Module for loading groups from GroupNames or the GAP computer algebra system.
 
+See https://groupnames.org and https://www.gap-system.org.
+
 Copyright 2023 The qLDPC Authors and Infleqtion Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,7 +43,11 @@ GROUPNAMES_URL = "https://people.maths.bris.ac.uk/~matyd/GroupNames/"
 def get_generators(
     group: str, *, warning_to_raise_if_calling_gap: str | None = None
 ) -> GeneratorsList:
-    """Retrieve GAP group generators."""
+    """Retrieve GAP group generators.
+
+    Tries a local database, then GAP (a subprocess), then a GroupNames.org web lookup, so this may
+    run GAP and access the network.
+    """
     # try retrieving a known group
     if generators := KNOWN_GROUPS.get(group):
         return generators
@@ -67,7 +73,12 @@ def get_generators(
 
 
 def get_generators_from_magma(group: str) -> GeneratorsList:
-    """Retrieve group generators from MAGMA."""
+    """Retrieve group generators from MAGMA.
+
+    Uses a manual copy/paste workflow: prints the command, copies it to the system clipboard, and
+    reads pasted output from standard input (blocking, and raising ``EOFError`` if standard input is
+    closed).
+    """
     print("Run the following command in MAGMA:")
     print()
     print(group)
@@ -133,7 +144,11 @@ def get_generators_from_magma(group: str) -> GeneratorsList:
 
 @qldpc.cache.use_disk_cache("small_group_number")
 def get_small_group_number(order: int) -> int:
-    """Get the number of 'SmallGroup's of a given order."""
+    """Get the number of 'SmallGroup's of a given order.
+
+    Uses the GAP SmallGrp package (https://gap-packages.github.io/SmallGrp/) if available, else a
+    GroupNames.org lookup.
+    """
     if qldpc.external.gap.is_installed():
         qldpc.external.gap.require_package("SmallGrp")
         command = f"Print(NumberSmallGroups({order}));;"
@@ -153,7 +168,8 @@ def get_small_group_number(order: int) -> int:
 
 def get_small_group_structure(order: int, index: int) -> str:
     """Get a description of the structure of a SmallGroup from GAP."""
-    # if we have the structure cached, retrieve it
+    # Cache manually (not via @use_disk_cache) so the fallback name returned when GAP is unavailable
+    # is never cached: only GAP's real StructureDescription (below) is stored.
     key = (order, index)
     cache = qldpc.cache.get_disk_cache("qldpc_group_structure")
     if structure := cache.get(key, None):
@@ -308,6 +324,8 @@ def maybe_get_webpage(order: int) -> str | None:
 )
 def get_primitive_central_idempotents(group: str, field: int) -> IdempotentsList | None:
     """Get the primitive central idempotents of a group algebra over a finite field.
+
+    Uses the GAP Wedderga package (https://gap-packages.github.io/wedderga/), run in a subprocess.
 
     Primitive central idempotents of a ring are nonzero elements that:
 

--- a/src/qldpc/external/groups.py
+++ b/src/qldpc/external/groups.py
@@ -45,8 +45,8 @@ def get_generators(
 ) -> GeneratorsList:
     """Retrieve GAP group generators.
 
-    Tries a local database, then GAP (a subprocess), then a GroupNames.org web lookup, so this may
-    run GAP and access the network.
+    This function tries a local database, then GAP (a subprocess), then a GroupNames.org web lookup,
+    so it may run GAP and access the network.
     """
     # try retrieving a known group
     if generators := KNOWN_GROUPS.get(group):
@@ -75,9 +75,9 @@ def get_generators(
 def get_generators_from_magma(group: str) -> GeneratorsList:
     """Retrieve group generators from MAGMA.
 
-    Uses a manual copy/paste workflow: prints the command, copies it to the system clipboard, and
-    reads pasted output from standard input (blocking, and raising ``EOFError`` if standard input is
-    closed).
+    This function uses a manual copy/paste workflow that prints the command, copies it to the
+    system clipboard, and reads the pasted output from standard input (blocking, and raising
+    ``EOFError`` if standard input is closed).
     """
     print("Run the following command in MAGMA:")
     print()
@@ -146,8 +146,8 @@ def get_generators_from_magma(group: str) -> GeneratorsList:
 def get_small_group_number(order: int) -> int:
     """Get the number of 'SmallGroup's of a given order.
 
-    Uses the GAP SmallGrp package (https://gap-packages.github.io/SmallGrp/) if available, else a
-    GroupNames.org lookup.
+    This function uses the GAP SmallGrp package (https://gap-packages.github.io/SmallGrp/) if
+    available, else a GroupNames.org lookup.
     """
     if qldpc.external.gap.is_installed():
         qldpc.external.gap.require_package("SmallGrp")
@@ -325,7 +325,8 @@ def maybe_get_webpage(order: int) -> str | None:
 def get_primitive_central_idempotents(group: str, field: int) -> IdempotentsList | None:
     """Get the primitive central idempotents of a group algebra over a finite field.
 
-    Uses the GAP Wedderga package (https://gap-packages.github.io/wedderga/), run in a subprocess.
+    This function uses the GAP Wedderga package (https://gap-packages.github.io/wedderga/), run in
+    a subprocess.
 
     Primitive central idempotents of a ring are nonzero elements that:
 

--- a/src/qldpc/external/groups.py
+++ b/src/qldpc/external/groups.py
@@ -146,6 +146,8 @@ def get_small_group_number(order: int) -> int:
         raise ValueError("Cannot determine the number of small groups")
 
     matches = re.findall(rf"<td>{order},([0-9]+)</td>", page_html)
+    if not matches:
+        raise ValueError("Cannot determine the number of small groups")
     return max(int(match) for match in matches)
 
 
@@ -217,7 +219,11 @@ def maybe_get_generators_from_groupnames(group: str) -> GeneratorsList | None:
     if group_url is None:
         # we cannot access the webpage
         return None
-    group_page = urllib.request.urlopen(group_url)
+    try:
+        group_page = urllib.request.urlopen(group_url, timeout=10)
+    except (urllib.error.URLError, TimeoutError):
+        # we cannot access the webpage
+        return None
     group_page_html = group_page.read().decode("utf-8")
 
     # extract section with the generators we are after
@@ -242,6 +248,9 @@ def parse_gap_permutations(permutations: str, cycle_sep: str = ",") -> Generator
     """
     parsed_permutations = []
     for line in permutations.strip().splitlines():
+        if not line.strip():
+            continue
+
         # extract list of cycles, where each cycle is a tuple of integers
         cycle_strings = line.strip()[1:-1].split(")(")
         try:
@@ -286,9 +295,9 @@ def maybe_get_webpage(order: int) -> str | None:
     """Try to retrieve the webpage listing all groups up to a given order."""
     try:
         url = GROUPNAMES_URL + ("index500.html" if order > 60 else "")
-        page = urllib.request.urlopen(url)
+        page = urllib.request.urlopen(url, timeout=10)
         return page.read().decode("utf-8")
-    except (urllib.error.URLError, urllib.error.HTTPError):
+    except (urllib.error.URLError, TimeoutError):
         # we cannot access the webpage
         return None
 

--- a/src/qldpc/external/groups_test.py
+++ b/src/qldpc/external/groups_test.py
@@ -91,6 +91,13 @@ def test_maybe_get_generators_from_groupnames() -> None:
     ):
         external.groups.maybe_get_generators_from_groupnames(GROUP)
 
+    # group webpage is unreachable
+    with (
+        unittest.mock.patch("qldpc.external.groups.get_group_url", return_value=GROUP_URL),
+        unittest.mock.patch("urllib.request.urlopen", side_effect=urllib.error.URLError("message")),
+    ):
+        assert external.groups.maybe_get_generators_from_groupnames(GROUP) is None
+
     # everything works as expected
     mock_page = get_mock_page(MOCK_GROUP_HTML)
     with (
@@ -98,6 +105,14 @@ def test_maybe_get_generators_from_groupnames() -> None:
         unittest.mock.patch("urllib.request.urlopen", return_value=mock_page),
     ):
         assert external.groups.maybe_get_generators_from_groupnames(GROUP) == GENERATORS
+
+
+def test_parse_gap_permutations() -> None:
+    """Parse GAP permutations, tolerating blank lines and the identity."""
+    # a blank line between permutations must not create a spurious identity generator
+    assert external.groups.parse_gap_permutations("(1,2)\n\n(3,4)") == [[(0, 1)], [(2, 3)]]
+    # the identity permutation parses to a generator with no cycles
+    assert external.groups.parse_gap_permutations("()") == [[]]
 
 
 def test_maybe_get_generators_from_gap() -> None:
@@ -213,9 +228,19 @@ def test_get_small_group_number() -> None:
     order, number = 16, 14
     text = rf"<td>{order},{number}</td>"
 
-    # fail to determine group number
+    # fail to determine group number: webpage is unreachable
     with (
         unittest.mock.patch("qldpc.external.groups.maybe_get_webpage", return_value=None),
+        unittest.mock.patch("qldpc.external.gap.is_installed", return_value=False),
+        pytest.raises(ValueError, match="Cannot determine"),
+    ):
+        external.groups.get_small_group_number(order)
+
+    # fail to determine group number: webpage has no matching entries
+    with (
+        unittest.mock.patch(
+            "qldpc.external.groups.maybe_get_webpage", return_value="<html></html>"
+        ),
         unittest.mock.patch("qldpc.external.gap.is_installed", return_value=False),
         pytest.raises(ValueError, match="Cannot determine"),
     ):


### PR DESCRIPTION
## What & why

`get_classical_code` and `_gap_define_sparse_matrix` assumed GAP's integer encoding of finite-field elements (`Int(x)` / `f*One(F)`) matches the one `galois` uses. That holds only over prime fields. Over `GF(p^k)` with `k > 1`, `f*One(F)` collapses to `(f mod p)*One(F)`, so matrices sent to GAP were silently corrupted (`get_distance_bound` returned a wrong distance), and `Int(x)` raised `IntFFE: <z> must lie in prime field` when reading extension-field elements back.

Each element is now mapped through the discrete logarithm of the field's primitive root instead: `Z(q)^log` when writing to GAP, `LogFFE(x, z)` when reading back (rebuilt in Python as `primitive_element ** log`). GAP and `galois` share that primitive element (both use Conway polynomials for the field orders that arise here), so the encoding is byte-identical over prime fields and correct over extension fields.

Verified against live GAP: a `GF(4)` hypergraph-product code with true Z-distance 2 previously received a bound of 1 (impossible for a correct upper bound) and now receives 2; reading a `GF(4)` GUAVA code no longer raises.

## Other fixes

- `get_output` now treats a nonzero GAP exit code as an error, not only nonempty stderr.
- Removed a duplicate, unguarded `pyperclip.copy` that crashed the manual copy/paste fallback on headless machines instead of printing instructions.
- `codes.py` imports `urllib.request` / `urllib.error` explicitly rather than relying on another module to import them first.
- The GroupNames lookups pass a `urlopen` timeout and catch connection failures, so an unreachable server degrades gracefully instead of hanging or raising uncaught.
- `get_quantum_code` catches `TimeoutError` alongside `urllib.error.URLError`, so a socket read-timeout during the qecdb fetch becomes the intended `Cannot access {url}` error instead of propagating raw, matching the GroupNames lookups.
- `get_classical_code` parses only lines that begin with `[` as check-matrix rows, so a stray GAP diagnostic line falls through to the descriptive "Could not determine the base field" / "Code has no parity checks" errors instead of an opaque `SyntaxError` from `ast.literal_eval`.
- `get_small_group_number` raises a clear error instead of `ValueError: max() arg is an empty sequence` when the index page has no matching entries.
- `parse_gap_permutations` skips blank lines instead of emitting a spurious identity generator.

## Documentation

Documented the modules' side effects (subprocess, network fetch, clipboard write, `git clone`, blocking stdin) and the randomized-upper-bound semantics of `get_distance_bound` (and its `maxav` argument); linked the GAP, GUAVA, Wedderga, SmallGrp, GroupNames, and qecdb references.

## Testing

Passes the project checks (`./checks/all_.py`: mypy, ruff lint + format, 100% coverage). The extension-field encode/decode round trip was additionally checked against a live GAP + QDistRnd install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)