### PR TITLE
`codes` module fixes (capacity estimation and logical operators)

### DIFF
--- a/src/qldpc/circuits/transversal.py
+++ b/src/qldpc/circuits/transversal.py
@@ -305,9 +305,9 @@ def get_transversal_circuits(
         *_, x_signs_m, z_signs_m = matching_tableau.to_numpy()
         for logical_qubit in range(code.dimension):
             if x_signs_l[logical_qubit] != x_signs_m[logical_qubit]:  # pragma: no cover
-                correction += codes.QuditCode.get_logical_ops(code, Pauli.Z)[logical_qubit]
+                correction += code.get_logical_ops(Pauli.Z, symplectic=True)[logical_qubit]
             if z_signs_l[logical_qubit] != z_signs_m[logical_qubit]:  # pragma: no cover
-                correction += codes.QuditCode.get_logical_ops(code, Pauli.X)[logical_qubit]
+                correction += code.get_logical_ops(Pauli.X, symplectic=True)[logical_qubit]
         correction_circuit = _get_pauli_circuit(op_to_string(correction))
 
         physical_circuits[tt] = correction_circuit + matching_circuit

--- a/src/qldpc/codes/_monte_carlo.py
+++ b/src/qldpc/codes/_monte_carlo.py
@@ -69,29 +69,46 @@ class ErrorRateFunc:
         """Max error weight considered."""
         return self.num_samples.size - 1
 
+    @staticmethod
+    def _as_divisor(counts: npt.NDArray[np.int_]) -> npt.NDArray[np.floating]:
+        """Cast sample counts to float for use as a divisor, mapping zeros to infinity.
+
+        Dividing by infinity sends the corresponding rate and variance to zero rather than to nan
+        or inf.  The reachable case is a weight whose samples were all discarded (zero kept
+        samples): it is then recorded as zero infidelity with zero variance, i.e. a weight that
+        never fails and is known to do so exactly.  This is optimistic -- such a weight carries no
+        information -- and is the zero-kept-samples end of the same effect that collapses the
+        variance to zero when a weight sees no failures.  A principled treatment (e.g. a Jeffreys
+        posterior) is deferred; see the error-bar follow-up notes.
+        """
+        divisor = counts.astype(float)
+        divisor[divisor == 0] = np.inf
+        return divisor
+
     @functools.cached_property
     def infidelities(self) -> npt.NDArray[np.floating]:
-        """Mean infidelity at each error weight."""
-        num_samples_kept = (self.num_samples - self.num_discards).astype(float)
-        num_samples_kept[num_samples_kept == 0] = np.inf
-        return self.num_failures / num_samples_kept
+        """Mean infidelity at each error weight.
+
+        A weight whose samples were all discarded has no kept samples and is reported as zero
+        infidelity; see _as_divisor for the caveat this carries.
+        """
+        return self.num_failures / self._as_divisor(self.num_samples - self.num_discards)
 
     @functools.cached_property
     def infidelity_variances(self) -> npt.NDArray[np.floating]:
         """Variance of the infidelity at each error weight."""
-        num_samples_kept = (self.num_samples - self.num_discards).astype(float)
-        num_samples_kept[num_samples_kept == 0] = np.inf
+        num_samples_kept = self._as_divisor(self.num_samples - self.num_discards)
         return self.infidelities * (1 - self.infidelities) / num_samples_kept
 
     @functools.cached_property
     def discard_rates(self) -> npt.NDArray[np.floating]:
         """Discard rate at each error weight."""
-        return self.num_discards / self.num_samples
+        return self.num_discards / self._as_divisor(self.num_samples)
 
     @functools.cached_property
     def discard_rate_variances(self) -> npt.NDArray[np.floating]:
         """Variance of the discard rate at each error weight."""
-        return self.discard_rates * (1 - self.discard_rates) / self.num_samples
+        return self.discard_rates * (1 - self.discard_rates) / self._as_divisor(self.num_samples)
 
     def __call__(
         self, error_rate: OneOrManyFloats, *, discard_rate: bool = False
@@ -180,8 +197,13 @@ def _get_error_probs_by_weight(
         probs[0] = 1
         return probs
     elif error_rate == 1:
+        # every location has an error, so the weight is exactly block_length with probability 1.
+        # If block_length exceeds max_weight then this weight lies outside the array and its
+        # probability is fully truncated, so leave all entries at zero (the missing mass is
+        # reported by truncation_error_bound) rather than indexing past the end of the array.
         probs = np.zeros(max_weight + 1)
-        probs[block_length:] = 1
+        if block_length <= max_weight:
+            probs[block_length] = 1
         return probs
 
     log_error_rate = np.log(error_rate)

--- a/src/qldpc/codes/_monte_carlo.py
+++ b/src/qldpc/codes/_monte_carlo.py
@@ -1,0 +1,212 @@
+"""Monte-Carlo helpers for code-capacity logical error rate estimation.
+
+These utilities turn the failure and discard counts collected by the .get_logical_error_rate_func
+methods of the code classes into logical error and discard rate estimates, and support the sampling
+that those methods perform.  They depend only on the decoder interface and elementary combinatorics,
+so they live in their own module.
+
+Copyright 2023 The qLDPC Authors and Infleqtion Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import functools
+from collections.abc import Iterable
+from typing import TypeVar
+
+import galois
+import numpy as np
+import numpy.typing as npt
+
+from qldpc import decoders, math
+
+OneOrManyFloats = TypeVar("OneOrManyFloats", float, Iterable[float])
+
+
+@dataclasses.dataclass
+class ErrorRateFunc:
+    """Container for raw simulation data used to compute logical error and discard rates.
+
+    An instance of this class is built and returned by the .get_logical_error_rate_func method of
+    ClassicalCode, QuditCode, and CSSCode.  If
+
+        func = code.get_logical_error_rate_func(...),
+
+    then "func" takes a physical error rate "p" as an argument, and returns two numbers:
+    (1) A logical error rate.
+    (2) An uncertainty (standard error) in the logical error rate.
+    If called with an array of physical error rates, this function returns two arrays.
+
+    If called with the keyword argument discard_rate=True, compute a discard rate rather than an
+    error rate.
+    """
+
+    # number of times we sampled each error weight
+    num_samples: npt.NDArray[np.int_]
+
+    # number of failures and discards by error weight
+    num_failures: npt.NDArray[np.int_]
+    num_discards: npt.NDArray[np.int_]
+
+    num_error_locations: int  # total number of error locations
+    max_error_rate: float  # largest physical error rate we can consider
+
+    @property
+    def max_error_weight(self) -> int:
+        """Max error weight considered."""
+        return self.num_samples.size - 1
+
+    @functools.cached_property
+    def infidelities(self) -> npt.NDArray[np.floating]:
+        """Mean infidelity at each error weight."""
+        num_samples_kept = (self.num_samples - self.num_discards).astype(float)
+        num_samples_kept[num_samples_kept == 0] = np.inf
+        return self.num_failures / num_samples_kept
+
+    @functools.cached_property
+    def infidelity_variances(self) -> npt.NDArray[np.floating]:
+        """Variance of the infidelity at each error weight."""
+        num_samples_kept = (self.num_samples - self.num_discards).astype(float)
+        num_samples_kept[num_samples_kept == 0] = np.inf
+        return self.infidelities * (1 - self.infidelities) / num_samples_kept
+
+    @functools.cached_property
+    def discard_rates(self) -> npt.NDArray[np.floating]:
+        """Discard rate at each error weight."""
+        return self.num_discards / self.num_samples
+
+    @functools.cached_property
+    def discard_rate_variances(self) -> npt.NDArray[np.floating]:
+        """Variance of the discard rate at each error weight."""
+        return self.discard_rates * (1 - self.discard_rates) / self.num_samples
+
+    def __call__(
+        self, error_rate: OneOrManyFloats, *, discard_rate: bool = False
+    ) -> tuple[OneOrManyFloats, OneOrManyFloats]:
+        """Compute the logical error rate (or discard rate) at a given physical error rate."""
+        if isinstance(error_rate, Iterable):
+            results = [self(rate, discard_rate=discard_rate) for rate in error_rate]
+            return (  # type:ignore[return-value]
+                np.array([result[0] for result in results]),
+                np.array([result[1] for result in results]),
+            )
+        if error_rate > self.max_error_rate:
+            raise ValueError(
+                "This ErrorRateFunc does not cover physical error rates greater than"
+                f" {self.max_error_rate}.  Try calling <YOUR_CODE>.get_logical_error_rate_func with"
+                " a larger max_error_rate."
+            )
+        weight_probs = _get_error_probs_by_weight(
+            self.num_error_locations, error_rate, self.max_error_weight
+        )
+        if discard_rate:
+            values = 1 - self.discard_rates
+            variances = self.discard_rate_variances
+        else:
+            values = 1 - self.infidelities
+            variances = self.infidelity_variances
+        value = weight_probs @ values
+        error = np.sqrt(weight_probs**2 @ variances)
+        return 1 - float(value), float(error)
+
+    def truncation_error_bound(self, error_rate: OneOrManyFloats) -> OneOrManyFloats:
+        """Upper bound on the truncation error in the infidelity or discard rate estimate."""
+        if isinstance(error_rate, Iterable):
+            values = [self.truncation_error_bound(rate) for rate in error_rate]
+            return np.array(values)  # type:ignore[return-value]
+        weight_probs = _get_error_probs_by_weight(
+            self.num_error_locations, error_rate, self.max_error_weight
+        )
+        return float(1.0 - weight_probs.sum())
+
+
+def _get_sample_allocation(
+    num_samples: int, block_length: int, max_error_rate: float
+) -> npt.NDArray[np.int_]:
+    """Construct an allocation of samples by error weight.
+
+    This method returns an array whose k-th entry is the number of samples to devote to errors of
+    weight k, given a maximum error rate that we care about.
+    """
+    probs = _get_error_probs_by_weight(block_length, max_error_rate)
+
+    # zero out the distribution at k=0, flatten it out to the left of its peak, and renormalize
+    probs[0] = 0
+    probs[1 : np.argmax(probs)] = probs.max()
+    probs /= np.sum(probs)
+
+    # assign sample numbers according to the probability distribution constructed above,
+    # increasing num_samples if necessary to deal with weird edge cases from round-off errors
+    while np.sum(sample_allocation := np.round(probs * num_samples).astype(int)) < num_samples:
+        num_samples += 1  # pragma: no cover
+
+    # allocate one sample to k=0 to fix an edge case in ErrorRateFunc
+    sample_allocation[0] = 1
+
+    # truncate trailing zeros and return
+    nonzero = np.nonzero(sample_allocation)[0]
+    return sample_allocation[: nonzero[-1] + 1]
+
+
+def _get_error_probs_by_weight(
+    block_length: int, error_rate: float, max_weight: int | None = None
+) -> npt.NDArray[np.floating]:
+    """Build an array whose k-th entry is the probability of a weight-k error in a code.
+
+    If a code has block_length n and each bit has an independent probability ``p = error_rate`` of
+    an error, then the probability of k errors is ``(n choose k) p**k (1-p)**(n-k)``.
+
+    We compute the above probability using logarithms because otherwise the combinatorial factor
+    ``(n choose k)`` might be too large to handle.
+    """
+    max_weight = max_weight or block_length
+
+    # deal with some pathological cases
+    if error_rate == 0:
+        probs = np.zeros(max_weight + 1)
+        probs[0] = 1
+        return probs
+    elif error_rate == 1:
+        probs = np.zeros(max_weight + 1)
+        probs[block_length:] = 1
+        return probs
+
+    log_error_rate = np.log(error_rate)
+    log_one_minus_error_rate = np.log(1 - error_rate)
+    log_probs = [
+        math.log_choose(block_length, kk)
+        + kk * log_error_rate
+        + (block_length - kk) * log_one_minus_error_rate
+        for kk in range(max_weight + 1)
+    ]
+    return np.exp(log_probs)
+
+
+def _get_error_and_erasure(
+    decoder: decoders.Decoder,
+    syndrome: galois.FieldArray,
+) -> tuple[galois.FieldArray, bool]:
+    """Decode a syndrome and return the inferred error together with an erasure flag.
+
+    If the decoder has a has_erasure_bit attribute set to True (e.g., a LookupDecoder constructed
+    with add_erasure_bit=True), the last element of the decoded vector is treated as the erasure
+    bit: 1 means the syndrome was not recognized and the sample should be discarded, 0 means a
+    correction was found normally.  The erasure bit is stripped before returning the error.
+    """
+    error = decoder.decode(syndrome.view(np.ndarray))
+    if getattr(decoder, "has_erasure_bit", False):
+        return error[:-1].view(type(syndrome)), bool(error[-1])
+    return error.view(type(syndrome)), False

--- a/src/qldpc/codes/_monte_carlo_test.py
+++ b/src/qldpc/codes/_monte_carlo_test.py
@@ -1,0 +1,112 @@
+"""Unit tests for _monte_carlo.py.
+
+Copyright 2023 The qLDPC Authors and Infleqtion Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from __future__ import annotations
+
+import galois
+import numpy as np
+import pytest
+
+from qldpc.codes import _monte_carlo
+
+
+def test_get_error_probs_by_weight() -> None:
+    """Probability of a weight-k error under an i.i.d. error model."""
+    # a zero error rate puts all probability on the weight-0 error
+    probs = _monte_carlo._get_error_probs_by_weight(5, 0.0)
+    assert probs[0] == 1 and probs[1:].sum() == 0
+
+    # a unit error rate puts all probability on the maximum weight
+    probs = _monte_carlo._get_error_probs_by_weight(5, 1.0)
+    assert probs.shape == (6,) and probs[5] == 1 and probs[:5].sum() == 0
+
+    # an intermediate error rate gives a normalized truncated binomial distribution
+    probs = _monte_carlo._get_error_probs_by_weight(5, 0.3, max_weight=3)
+    assert probs.shape == (4,) and np.all(probs >= 0)
+    assert np.isclose(probs.sum(), sum(_monte_carlo._get_error_probs_by_weight(5, 0.3)[:4]))
+
+
+def test_get_sample_allocation() -> None:
+    """Allocation of samples across error weights."""
+    allocation = _monte_carlo._get_sample_allocation(1000, block_length=10, max_error_rate=0.2)
+    assert allocation[0] == 1  # exactly one sample is reserved for the weight-0 error
+    assert np.sum(allocation) >= 1000  # every requested sample is allocated
+    assert allocation[-1] > 0  # trailing zeros are truncated
+
+
+def test_get_error_and_erasure() -> None:
+    """Decoding a syndrome, with and without an erasure bit."""
+    field = galois.GF2
+    syndrome = field([1, 0, 1])
+
+    class _Decoder:
+        def __init__(self, output: np.ndarray, has_erasure_bit: bool = False) -> None:
+            self.output = output
+            if has_erasure_bit:
+                self.has_erasure_bit = True
+
+        def decode(self, syndrome: np.ndarray) -> np.ndarray:
+            return self.output
+
+    # a plain decoder returns the inferred error and no erasure
+    decoder = _Decoder(np.array([1, 1, 0, 0], dtype=np.uint8))
+    error, erasure = _monte_carlo._get_error_and_erasure(decoder, syndrome)
+    assert not erasure and isinstance(error, field) and np.array_equal(error, field([1, 1, 0, 0]))
+
+    # an erasure-enabled decoder strips the last (erasure) bit and reports it
+    decoder = _Decoder(np.array([1, 1, 0, 0, 1], dtype=np.uint8), has_erasure_bit=True)
+    error, erasure = _monte_carlo._get_error_and_erasure(decoder, syndrome)
+    assert erasure and np.array_equal(error, field([1, 1, 0, 0]))
+
+
+def test_error_rate_func() -> None:
+    """Convert raw failure and discard counts into error and discard rate estimates."""
+    func = _monte_carlo.ErrorRateFunc(
+        num_samples=np.array([1, 100, 100]),
+        num_failures=np.array([0, 10, 50]),
+        num_discards=np.array([0, 0, 100]),  # every weight-2 sample is discarded
+        num_error_locations=5,
+        max_error_rate=0.5,
+    )
+    assert func.max_error_weight == 2
+
+    # a weight whose samples are all discarded has an undefined infidelity, recorded as zero
+    assert func.infidelities[2] == 0
+    assert np.isclose(func.infidelities[1], 0.1)
+    assert np.all(func.infidelity_variances >= 0)
+    assert np.array_equal(func.discard_rates, [0, 0, 1])
+    assert np.all(func.discard_rate_variances >= 0)
+
+    # a scalar physical error rate yields a (rate, uncertainty) pair, for errors and discards alike
+    error_rate, uncertainty = func(0.1)
+    assert 0 <= error_rate <= 1 and uncertainty >= 0
+    discard_rate, uncertainty = func(0.1, discard_rate=True)
+    assert 0 <= discard_rate <= 1 and uncertainty >= 0
+
+    # an iterable of physical error rates yields arrays of rates and uncertainties
+    rates, uncertainties = func([0.0, 0.1])
+    rates, uncertainties = np.asarray(rates), np.asarray(uncertainties)
+    assert rates.shape == (2,) and uncertainties.shape == (2,)
+    assert rates[0] == 0  # a zero physical error rate gives a zero logical error rate
+
+    # physical error rates beyond the constructed range are rejected
+    with pytest.raises(ValueError, match="does not cover"):
+        func(0.9)
+
+    # the truncation error bound is available for scalar and iterable inputs
+    assert 0 <= func.truncation_error_bound(0.1) <= 1
+    assert np.asarray(func.truncation_error_bound([0.1, 0.2])).shape == (2,)

--- a/src/qldpc/codes/common.py
+++ b/src/qldpc/codes/common.py
@@ -19,13 +19,13 @@ from __future__ import annotations
 
 import abc
 import collections
-import dataclasses
+import copy
 import functools
 import itertools
 import random
 import warnings
-from collections.abc import Callable, Collection, Iterable, Iterator, Mapping, Sequence
-from typing import Any, TypeVar, cast
+from collections.abc import Callable, Collection, Iterator, Mapping, Sequence
+from typing import Any, cast
 
 import galois
 import numpy as np
@@ -40,6 +40,7 @@ from qldpc._util import networkx as nx
 from qldpc.math import IntegerArray
 from qldpc.objects import PAULIS_XZ, Node, Pauli, PauliXZ, QuditPauli
 
+from ._monte_carlo import ErrorRateFunc, _get_error_and_erasure, _get_sample_allocation
 from .distance import get_distance_classical, get_distance_quantum
 
 Slice = slice | npt.NDArray[np.int_] | list[int]
@@ -1050,6 +1051,9 @@ class QuditCode(AbstractCode):
         """
         # build a graph whose vertices are checks, and edges connect checks with overlapping support
         check_graph = nx.Graph()
+        # seed every check that appears in the Tanner graph, so that a check whose support overlaps
+        # no other check still gets colored (and its edges collected) below
+        check_graph.add_nodes_from(node for node in self.graph if not node.is_data)
         for qubit in range(len(self)):
             data_node = Node(qubit, is_data=True)
             check_nodes = self.graph.predecessors(data_node)
@@ -2066,7 +2070,9 @@ class QuditCode(AbstractCode):
         if (num_inner_blocks := len(inner_physical_to_outer_logical) // len(inner)) > 1:
             inner = inner.stack([inner] * num_inner_blocks)
 
-        # permute logical operators of the outer code
+        # permute logical operators of the outer code, working on a copy so that the caller's code
+        # object is left unmodified
+        outer = copy.copy(outer)
         outer._logical_ops = (
             outer.get_logical_ops()
             .reshape(2, outer.dimension, -1)[:, inner_physical_to_outer_logical, :]
@@ -2097,6 +2103,13 @@ class QuditCode(AbstractCode):
         code error (obtained by sampling independent errors on all qubits) is converted into a
         logical error by the decoder.
 
+        For a subsystem code, errors are decoded against the stabilizer generators of the code, so
+        a syndrome has one entry per stabilizer generator.  These generators can be high-weight
+        (for example, the stabilizers of a Bacon-Shor code have weight proportional to the code's
+        linear size), which general-purpose decoders may handle poorly.  The estimate is still
+        computed correctly, but it can overestimate the logical error rate achievable with a
+        decoder tailored to the code.
+
         See help(qldpc.codes.ClassicalCode.get_logical_error_rate_func) for more details about how
         this method works.
         """
@@ -2109,10 +2122,10 @@ class QuditCode(AbstractCode):
         else:
             pauli_bias_zxy = None
 
-        # construct decoders
-        decoder = decoders.get_decoder(
-            math.symplectic_conjugate(self.matrix).view(np.ndarray), **decoder_kwargs
-        )
+        # construct a decoder from the stabilizer generators of the code; the syndrome matrix is a
+        # field array, from which get_decoder selects a decoder appropriate to the field
+        stabilizer_ops = self.get_stabilizer_ops()
+        decoder = decoders.get_decoder(math.symplectic_conjugate(stabilizer_ops), **decoder_kwargs)
 
         # identify logical operators
         logical_ops = self.get_logical_ops()
@@ -2124,7 +2137,12 @@ class QuditCode(AbstractCode):
         for weight in range(1, len(sample_allocation)):
             num_failures[weight], num_discards[weight] = (
                 self._estimate_decoding_fidelity_and_variance(
-                    weight, sample_allocation[weight], decoder, logical_ops, pauli_bias_zxy
+                    weight,
+                    sample_allocation[weight],
+                    decoder,
+                    stabilizer_ops,
+                    logical_ops,
+                    pauli_bias_zxy,
                 )
             )
         return ErrorRateFunc(
@@ -2136,16 +2154,22 @@ class QuditCode(AbstractCode):
         error_weight: int,
         num_samples: int,
         decoder: decoders.Decoder,
+        stabilizer_ops: npt.NDArray[np.int_],
         logical_ops: npt.NDArray[np.int_],
         pauli_bias_zxy: npt.NDArray[np.floating] | None,
     ) -> tuple[int, int]:
         """Sample and correct errors of a fixed weight.
 
+        Syndromes are computed against the stabilizer generators in stabilizer_ops, which is the
+        matrix that the decoder is built to invert.  For a subsystem code the stabilizer generators
+        are a strict subset of the parity checks (the gauge generators), so a syndrome vector has
+        one entry per stabilizer generator rather than one per gauge generator.
+
         Return logical error and discard counts.
         """
         num_failures = 0
         num_discards = 0
-        syndrome_matrix = -math.symplectic_conjugate(self.matrix)
+        syndrome_matrix = -math.symplectic_conjugate(stabilizer_ops)
         for _ in range(num_samples):
             # construct an error
             error_locations = np.random.choice(range(len(self)), size=error_weight, replace=False)
@@ -3280,6 +3304,13 @@ class CSSCode(QuditCode):
         code error (obtained by sampling independent errors on all qubits) is converted into a
         logical error by the decoder.
 
+        For a subsystem code, errors are decoded against the stabilizer generators of the code, so
+        a syndrome has one entry per stabilizer generator.  These generators can be high-weight
+        (for example, the stabilizers of a Bacon-Shor code have weight proportional to the code's
+        linear size), which general-purpose decoders may handle poorly.  The estimate is still
+        computed correctly, but it can overestimate the logical error rate achievable with a
+        decoder tailored to the code.
+
         See help(qldpc.codes.ClassicalCode.get_logical_error_rate_func) for more details about how
         this method works.
         """
@@ -3294,14 +3325,15 @@ class CSSCode(QuditCode):
 
         stabilizer_ops_x = self.get_stabilizer_ops(Pauli.X, canonicalized=False)
         stabilizer_ops_z = self.get_stabilizer_ops(Pauli.Z, canonicalized=False)
+
+        # construct decoders; the X-type and Z-type decoders can be shared when they are built from
+        # equal stabilizers with equal (fully merged) decoder arguments
+        decoder_x_kwargs = (decoder_x_kwargs or {}) | decoder_kwargs
+        decoder_z_kwargs = (decoder_z_kwargs or {}) | decoder_kwargs
         same_x_and_z = (
             np.array_equal(stabilizer_ops_x, stabilizer_ops_z)
             and decoder_x_kwargs == decoder_z_kwargs
         )
-
-        # construct decoders
-        decoder_x_kwargs = (decoder_x_kwargs or {}) | decoder_kwargs
-        decoder_z_kwargs = (decoder_z_kwargs or {}) | decoder_kwargs
         decoder_x = decoders.get_decoder(stabilizer_ops_z, **decoder_x_kwargs)
         decoder_z = (
             decoder_x
@@ -3324,6 +3356,8 @@ class CSSCode(QuditCode):
                     sample_allocation[weight],
                     decoder_x,
                     decoder_z,
+                    stabilizer_ops_x,
+                    stabilizer_ops_z,
                     logicals_x,
                     logicals_z,
                     pauli_bias_zxy,
@@ -3339,11 +3373,19 @@ class CSSCode(QuditCode):
         num_samples: int,
         decoder_x: decoders.Decoder,
         decoder_z: decoders.Decoder,
+        stabilizer_ops_x: npt.NDArray[np.int_],
+        stabilizer_ops_z: npt.NDArray[np.int_],
         logicals_x: npt.NDArray[np.int_],
         logicals_z: npt.NDArray[np.int_],
         pauli_bias_zxy: npt.NDArray[np.floating] | None,
     ) -> tuple[int, int]:
         """Sample and correct errors of a fixed weight.
+
+        Syndromes are computed against the stabilizer generators in stabilizer_ops_x and
+        stabilizer_ops_z, which are the matrices that decoder_z and decoder_x are respectively built
+        to invert.  For a subsystem code the stabilizer generators are a strict subset of the parity
+        checks (the gauge generators), so a syndrome vector has one entry per stabilizer generator
+        rather than one per gauge generator.
 
         Return logical error and discard counts.
         """
@@ -3360,7 +3402,7 @@ class CSSCode(QuditCode):
             error_z[error_locs_z] = np.random.choice(
                 range(1, self.field.order), size=len(error_locs_z)
             )
-            syndrome_z = self.matrix_x @ error_z
+            syndrome_z = stabilizer_ops_x @ error_z
             decoded_error_z, erasure = _get_error_and_erasure(decoder_z, syndrome_z)
             if erasure:
                 num_discards += 1
@@ -3379,7 +3421,7 @@ class CSSCode(QuditCode):
             error_x[error_locs_x] = np.random.choice(
                 range(1, self.field.order), size=len(error_locs_x)
             )
-            syndrome_x = self.matrix_z @ error_x
+            syndrome_x = stabilizer_ops_z @ error_x
             decoded_error_x, erasure = _get_error_and_erasure(decoder_x, syndrome_x)
             if erasure:
                 num_discards += 1
@@ -3388,185 +3430,6 @@ class CSSCode(QuditCode):
                 num_failures += 1
 
         return num_failures, num_discards
-
-
-OneOrManyFloats = TypeVar("OneOrManyFloats", float, Iterable[float])
-
-
-@dataclasses.dataclass
-class ErrorRateFunc:
-    """Container for raw simulation data used to compute logical error and discard rates.
-
-    An instance of this class is built and returned by the .get_logical_error_rate_func method of
-    ClassicalCode, QuditCode, and CSSCode.  If
-
-        func = code.get_logical_error_rate_func(...),
-
-    then "func" takes a physical error rate "p" as an argument, and returns two numbers:
-    (1) A logical error rate.
-    (2) An uncertainty (standard error) in the logical error rate.
-    If called with an array of physical error rates, this function returns two arrays.
-
-    If called with the keyword argument discard_rate=True, compute a discard rate rather than an
-    error rate.
-    """
-
-    # number of times we sampled each error weight
-    num_samples: npt.NDArray[np.int_]
-
-    # number of failures and discards by error weight
-    num_failures: npt.NDArray[np.int_]
-    num_discards: npt.NDArray[np.int_]
-
-    num_error_locations: int  # total number of error locations
-    max_error_rate: float  # largest physical error rate we can consider
-
-    @property
-    def max_error_weight(self) -> int:
-        """Max error weight considered."""
-        return self.num_samples.size - 1
-
-    @functools.cached_property
-    def infidelities(self) -> npt.NDArray[np.floating]:
-        """Mean infidelity at each error weight."""
-        num_samples_kept = (self.num_samples - self.num_discards).astype(float)
-        num_samples_kept[num_samples_kept == 0] = np.inf
-        return self.num_failures / num_samples_kept
-
-    @functools.cached_property
-    def infidelity_variances(self) -> npt.NDArray[np.floating]:
-        """Variance of the infidelity at each error weight."""
-        num_samples_kept = (self.num_samples - self.num_discards).astype(float)
-        num_samples_kept[num_samples_kept == 0] = np.inf
-        return self.infidelities * (1 - self.infidelities) / num_samples_kept
-
-    @functools.cached_property
-    def discard_rates(self) -> npt.NDArray[np.floating]:
-        """Discard rate at each error weight."""
-        return self.num_discards / self.num_samples
-
-    @functools.cached_property
-    def discard_rate_variances(self) -> npt.NDArray[np.floating]:
-        """Variance of the discard rate at each error weight."""
-        return self.discard_rates * (1 - self.discard_rates) / self.num_samples
-
-    def __call__(
-        self, error_rate: OneOrManyFloats, *, discard_rate: bool = False
-    ) -> tuple[OneOrManyFloats, OneOrManyFloats]:
-        """Compute the logical error rate (or discard rate) at a given physical error rate."""
-        if isinstance(error_rate, Iterable):
-            results = [self(rate, discard_rate=discard_rate) for rate in error_rate]
-            return (  # type:ignore[return-value]
-                np.array([result[0] for result in results]),
-                np.array([result[1] for result in results]),
-            )
-        if error_rate > self.max_error_rate:
-            raise ValueError(
-                "This ErrorRateFunc does not cover physical error rates greater than"
-                f" {self.max_error_rate}.  Try calling <YOUR_CODE>.get_logical_error_rate_func with"
-                " a larger max_error_rate."
-            )
-        weight_probs = _get_error_probs_by_weight(
-            self.num_error_locations, error_rate, self.max_error_weight
-        )
-        if discard_rate:
-            values = 1 - self.discard_rates
-            variances = self.discard_rate_variances
-        else:
-            values = 1 - self.infidelities
-            variances = self.infidelity_variances
-        value = weight_probs @ values
-        error = np.sqrt(weight_probs**2 @ variances)
-        return 1 - float(value), float(error)
-
-    def truncation_error_bound(self, error_rate: OneOrManyFloats) -> OneOrManyFloats:
-        """Upper bound on the truncation error in the infidelity or discard rate estimate."""
-        if isinstance(error_rate, Iterable):
-            values = [self.truncation_error_bound(rate) for rate in error_rate]
-            return np.array(values)  # type:ignore[return-value]
-        weight_probs = _get_error_probs_by_weight(
-            self.num_error_locations, error_rate, self.max_error_weight
-        )
-        return float(1.0 - weight_probs.sum())
-
-
-def _get_sample_allocation(
-    num_samples: int, block_length: int, max_error_rate: float
-) -> npt.NDArray[np.int_]:
-    """Construct an allocation of samples by error weight.
-
-    This method returns an array whose k-th entry is the number of samples to devote to errors of
-    weight k, given a maximum error rate that we care about.
-    """
-    probs = _get_error_probs_by_weight(block_length, max_error_rate)
-
-    # zero out the distribution at k=0, flatten it out to the left of its peak, and renormalize
-    probs[0] = 0
-    probs[1 : np.argmax(probs)] = probs.max()
-    probs /= np.sum(probs)
-
-    # assign sample numbers according to the probability distribution constructed above,
-    # increasing num_samples if necessary to deal with weird edge cases from round-off errors
-    while np.sum(sample_allocation := np.round(probs * num_samples).astype(int)) < num_samples:
-        num_samples += 1  # pragma: no cover
-
-    # allocate one sample to k=0 to fix an edge case in ErrorRateFunc
-    sample_allocation[0] = 1
-
-    # truncate trailing zeros and return
-    nonzero = np.nonzero(sample_allocation)[0]
-    return sample_allocation[: nonzero[-1] + 1]
-
-
-def _get_error_probs_by_weight(
-    block_length: int, error_rate: float, max_weight: int | None = None
-) -> npt.NDArray[np.floating]:
-    """Build an array whose k-th entry is the probability of a weight-k error in a code.
-
-    If a code has block_length n and each bit has an independent probability ``p = error_rate`` of
-    an error, then the probability of k errors is ``(n choose k) p**k (1-p)**(n-k)``.
-
-    We compute the above probability using logarithms because otherwise the combinatorial factor
-    ``(n choose k)`` might be too large to handle.
-    """
-    max_weight = max_weight or block_length
-
-    # deal with some pathological cases
-    if error_rate == 0:
-        probs = np.zeros(max_weight + 1)
-        probs[0] = 1
-        return probs
-    elif error_rate == 1:
-        probs = np.zeros(max_weight + 1)
-        probs[block_length:] = 1
-        return probs
-
-    log_error_rate = np.log(error_rate)
-    log_one_minus_error_rate = np.log(1 - error_rate)
-    log_probs = [
-        math.log_choose(block_length, kk)
-        + kk * log_error_rate
-        + (block_length - kk) * log_one_minus_error_rate
-        for kk in range(max_weight + 1)
-    ]
-    return np.exp(log_probs)
-
-
-def _get_error_and_erasure(
-    decoder: decoders.Decoder,
-    syndrome: galois.FieldArray,
-) -> tuple[galois.FieldArray, bool]:
-    """Decode a syndrome and return the inferred error together with an erasure flag.
-
-    If the decoder has a has_erasure_bit attribute set to True (e.g., a LookupDecoder constructed
-    with add_erasure_bit=True), the last element of the decoded vector is treated as the erasure
-    bit: 1 means the syndrome was not recognized and the sample should be discarded, 0 means a
-    correction was found normally.  The erasure bit is stripped before returning the error.
-    """
-    error = decoder.decode(syndrome.view(np.ndarray))
-    if getattr(decoder, "has_erasure_bit", False):
-        return error[:-1].view(type(syndrome)), bool(error[-1])
-    return error.view(type(syndrome)), False
 
 
 def _join_slices(*sectors: Slice) -> npt.NDArray[np.int_]:

--- a/src/qldpc/codes/common.py
+++ b/src/qldpc/codes/common.py
@@ -1463,10 +1463,14 @@ class QuditCode(AbstractCode):
         logical_ops = np.asanyarray(logical_ops).view(self.field)
         if not skip_validation:
             dimension = len(logical_ops) // 2
-            logical_ops_x = logical_ops[:dimension]
-            logical_ops_z = logical_ops[dimension:]
-            inner_products = logical_ops_x @ math.symplectic_conjugate(logical_ops_z).T
-            if not np.array_equal(inner_products, np.eye(dimension, dtype=int)):
+            # A valid logical basis has symplectic Gram matrix equal to the block anti-diagonal
+            # [[0, I], [-I, 0]]: the X-type logicals mutually commute, the Z-type logicals mutually
+            # commute, and logical j anticommutes only with its dual logical j + dimension.
+            gram = logical_ops @ math.symplectic_conjugate(logical_ops).T
+            expected_gram = self.field.Zeros((2 * dimension, 2 * dimension))
+            expected_gram[:dimension, dimension:] = self.field.Identity(dimension)
+            expected_gram[dimension:, :dimension] = -self.field.Identity(dimension)
+            if not np.array_equal(gram, expected_gram):
                 raise ValueError("The given logical operators have incorrect commutation relations")
             if np.any(self.matrix @ math.symplectic_conjugate(logical_ops).T):
                 raise ValueError("The given logical operators violate parity checks")

--- a/src/qldpc/codes/common.py
+++ b/src/qldpc/codes/common.py
@@ -1187,6 +1187,15 @@ class QuditCode(AbstractCode):
         The symplectic argument is provided for compatibility with CSSCode.get_logical_ops, and must
         always be True for a non-CSS code.
         """
+        # Subclasses store logical operators in their own format in the shared self._logical_ops
+        # cache (for example, CSSCode caches the block-diagonal single-type form).  If this base
+        # implementation is invoked directly on such a subclass instance, defer to the subclass so
+        # that the cache is read and written in that subclass's format.
+        if type(self).get_logical_ops is not QuditCode.get_logical_ops:
+            return type(self).get_logical_ops(
+                self, pauli, recompute=recompute, symplectic=symplectic
+            )
+
         assert symplectic is True
         assert pauli is None or pauli in PAULIS_XZ
 

--- a/src/qldpc/codes/common.py
+++ b/src/qldpc/codes/common.py
@@ -794,16 +794,14 @@ class ClassicalCode(AbstractCode):
         num_failures = np.zeros(sample_allocation.size, dtype=int)
         num_discards = np.zeros(sample_allocation.size, dtype=int)
         for weight in range(1, len(sample_allocation)):
-            num_failures[weight], num_discards[weight] = (
-                self._estimate_decoding_infidelity_and_variance(
-                    weight, sample_allocation[weight], decoder
-                )
+            num_failures[weight], num_discards[weight] = self._sample_failure_and_discard_counts(
+                weight, sample_allocation[weight], decoder
             )
         return ErrorRateFunc(
             sample_allocation, num_failures, num_discards, len(self), float(max_error_rate)
         )
 
-    def _estimate_decoding_infidelity_and_variance(
+    def _sample_failure_and_discard_counts(
         self, error_weight: int, num_samples: int, decoder: decoders.Decoder
     ) -> tuple[int, int]:
         """Sample and correct errors of a fixed weight.
@@ -1103,6 +1101,9 @@ class QuditCode(AbstractCode):
                 check = " ".join(check)
             return check.split()
 
+        if not checks:
+            raise ValueError("Cannot build a QuditCode from an empty collection of parity checks")
+
         check_ops = [parse_check(check) for check in checks]
 
         num_checks = len(checks)
@@ -1110,7 +1111,10 @@ class QuditCode(AbstractCode):
         matrix = np.zeros((num_checks, 2, num_qudits), dtype=int)
         for index, check_op in enumerate(check_ops):
             if len(check_op) != num_qudits:
-                raise ValueError(f"Parity checks 0 and {index} have different lengths")
+                raise ValueError(
+                    f"Parity checks 0 and {index} have different lengths"
+                    f" ({num_qudits} and {len(check_op)})"
+                )
             for qudit, op in enumerate(check_op):
                 matrix[index, :, qudit] = operator.from_string(op).value
 
@@ -1141,7 +1145,7 @@ class QuditCode(AbstractCode):
         if self.field is not galois.GF2:
             raise ValueError(
                 "You asked for the number of qubits in this code, but this code is built out of "
-                rf"{self.field.order}-dimensional qudits.\nTry calling {type(self)}.num_qudits."
+                f"{self.field.order}-dimensional qudits.  Try calling {type(self).__name__}.num_qudits."
             )
         return len(self)
 
@@ -1494,11 +1498,6 @@ class QuditCode(AbstractCode):
         to get ``Lz = (Kz @ Ω.T @ Lx.T)**-1 @ Kz``.
         """
         logicals_ops_x = np.asanyarray(logicals_ops_x).view(self.field)
-        if logicals_ops_x.shape[1] == len(self):  # pragma: no cover
-            # assume the logicals have only X support
-            logicals_ops_x = np.hstack(
-                [logicals_ops_x, self.field.Zeros((self.dimension, len(self)))]
-            ).view(self.field)
         old_logicals_z = self.get_logical_ops(Pauli.Z, symplectic=True)
         basis_change = np.linalg.inv(math.symplectic_conjugate(old_logicals_z) @ logicals_ops_x.T)
         new_logicals_z = basis_change @ old_logicals_z
@@ -1528,11 +1527,6 @@ class QuditCode(AbstractCode):
         to get ``Lx = (Kx @ Ω @ Lz.T)**-1 @ Kx``.
         """
         logicals_ops_z = np.asanyarray(logicals_ops_z).view(self.field)
-        if logicals_ops_z.shape[1] == len(self):  # pragma: no cover
-            # assume the logicals have only Z support
-            logicals_ops_z = np.hstack(
-                [self.field.Zeros((self.dimension, len(self))), logicals_ops_z]
-            ).view(self.field)
         old_logicals_x = self.get_logical_ops(Pauli.X, symplectic=True)
         basis_change = np.linalg.inv(old_logicals_x @ math.symplectic_conjugate(logicals_ops_z).T)
         new_logicals_x = basis_change @ old_logicals_x
@@ -1616,6 +1610,12 @@ class QuditCode(AbstractCode):
         Destabilizers are defined relative to a specific minimal choice of stabilizer generators.
         This method first considers the stabilizer matrix built by self.get_stabilizer_ops().  If
         that choice is overcomplete, this method uses self.get_stabilizer_ops(canonicalized=True).
+
+        If a pauli (Pauli.X or Pauli.Z) is provided, return only the destabilizers whose leading
+        (first nonzero) entry has that type.  Since each destabilizer anticommutes with the single
+        stabilizer generator it is paired with, these are the destabilizers dual to the stabilizer
+        generators of the opposite type: Pauli.X selects the destabilizers dual to the Z-type
+        stabilizers, and Pauli.Z those dual to the X-type stabilizers.
 
         The symplectic argument is provided for compatibility with CSSCode.get_destabilizer_ops, and
         must always be True for a non-CSS code.
@@ -2135,21 +2135,19 @@ class QuditCode(AbstractCode):
         num_failures = np.zeros(sample_allocation.size, dtype=int)
         num_discards = np.zeros(sample_allocation.size, dtype=int)
         for weight in range(1, len(sample_allocation)):
-            num_failures[weight], num_discards[weight] = (
-                self._estimate_decoding_fidelity_and_variance(
-                    weight,
-                    sample_allocation[weight],
-                    decoder,
-                    stabilizer_ops,
-                    logical_ops,
-                    pauli_bias_zxy,
-                )
+            num_failures[weight], num_discards[weight] = self._sample_failure_and_discard_counts(
+                weight,
+                sample_allocation[weight],
+                decoder,
+                stabilizer_ops,
+                logical_ops,
+                pauli_bias_zxy,
             )
         return ErrorRateFunc(
             sample_allocation, num_failures, num_discards, len(self), float(max_error_rate)
         )
 
-    def _estimate_decoding_fidelity_and_variance(
+    def _sample_failure_and_discard_counts(
         self,
         error_weight: int,
         num_samples: int,
@@ -2236,7 +2234,13 @@ class CSSCode(QuditCode):
         is_subsystem_code: bool | None = None,
         promise_equal_distance_xz: bool = False,  # do X and Z logicals have equal minimum weight?
     ) -> None:
-        """Build a CSSCode from classical subcodes that specify X-type and Z-type parity checks."""
+        """Build a CSSCode from classical subcodes that specify X-type and Z-type parity checks.
+
+        If promise_equal_distance_xz is True, the X-type and Z-type logical operators are assumed to
+        have equal minimum weight, which lets the code distance be computed from one type alone.
+        This promise is trusted rather than verified: passing True when it does not hold makes
+        get_distance return an incorrect (and compute-order-dependent) distance.
+        """
         self._code_x = ClassicalCode(code_x, field)  # X-type parity checks, measuring Z-type errors
         self._code_z = ClassicalCode(code_z, field)  # Z-type parity checks, measuring X-type errors
         self._field = self.code_x.field
@@ -2941,7 +2945,7 @@ class CSSCode(QuditCode):
 
     def _get_distance_exact(self, pauli: PauliXZ | None) -> int | float:
         """Method for subclasses to compute specialized exact distance calculations."""
-        return NotImplemented  # pragma: no cover
+        return NotImplemented
 
     def get_distance_if_known(self, pauli: PauliXZ | None = None) -> int | float | None:
         """Retrieve a distance, if known.
@@ -2967,8 +2971,8 @@ class CSSCode(QuditCode):
     def get_distance_bound(
         self,
         num_trials: int = 1,
-        pauli: PauliXZ | None = None,
         *,
+        pauli: PauliXZ | None = None,
         cutoff: int | None = None,
         **bound_kwargs: Any,
     ) -> int | float:
@@ -3351,7 +3355,7 @@ class CSSCode(QuditCode):
         num_discards = np.zeros(sample_allocation.size, dtype=int)
         for weight in range(1, len(sample_allocation)):
             num_failures[weight], num_discards[weight] = (
-                self._estimate_css_decoding_fidelity_and_variance(
+                self._sample_css_failure_and_discard_counts(
                     weight,
                     sample_allocation[weight],
                     decoder_x,
@@ -3367,7 +3371,7 @@ class CSSCode(QuditCode):
             sample_allocation, num_failures, num_discards, len(self), float(max_error_rate)
         )
 
-    def _estimate_css_decoding_fidelity_and_variance(
+    def _sample_css_failure_and_discard_counts(
         self,
         error_weight: int,
         num_samples: int,

--- a/src/qldpc/codes/common.py
+++ b/src/qldpc/codes/common.py
@@ -1187,15 +1187,6 @@ class QuditCode(AbstractCode):
         The symplectic argument is provided for compatibility with CSSCode.get_logical_ops, and must
         always be True for a non-CSS code.
         """
-        # Subclasses store logical operators in their own format in the shared self._logical_ops
-        # cache (for example, CSSCode caches the block-diagonal single-type form).  If this base
-        # implementation is invoked directly on such a subclass instance, defer to the subclass so
-        # that the cache is read and written in that subclass's format.
-        if type(self).get_logical_ops is not QuditCode.get_logical_ops:
-            return type(self).get_logical_ops(
-                self, pauli, recompute=recompute, symplectic=symplectic
-            )
-
         assert symplectic is True
         assert pauli is None or pauli in PAULIS_XZ
 
@@ -1489,6 +1480,14 @@ class QuditCode(AbstractCode):
         self._dimension = len(logical_ops) // 2
         return self
 
+    def _validate_logical_ops_shape(self, logical_ops: galois.FieldArray) -> None:
+        """Require a 2D matrix with one row per logical qudit."""
+        if logical_ops.ndim != 2 or len(logical_ops) != self.dimension:
+            raise ValueError(
+                f"Expected {self.dimension} logical operators, got an array of shape "
+                f"{logical_ops.shape}"
+            )
+
     def set_logical_ops_x(
         self,
         logicals_ops_x: npt.NDArray[np.int_] | Sequence[Sequence[int]],
@@ -1509,8 +1508,19 @@ class QuditCode(AbstractCode):
 
         Plugging (1) into (2), we find ``M = (Kz @ Ω.T @ Lx.T)**-1``, and in turn plug M into (1)
         to get ``Lz = (Kz @ Ω.T @ Lx.T)**-1 @ Kz``.
+
+        The X-type logical operators are given by a matrix with shape ``(k, 2*n)``.  As a
+        convenience, a matrix with shape ``(k, n)`` is also accepted, in which case its entries are
+        taken to be the X-type support of X-only logical operators (that is, with zero Z-type
+        support).
         """
         logicals_ops_x = np.asanyarray(logicals_ops_x).view(self.field)
+        self._validate_logical_ops_shape(logicals_ops_x)
+        if logicals_ops_x.shape[1] == len(self):
+            # the given logical operators have only X-type support
+            logicals_ops_x = np.hstack(
+                [logicals_ops_x, self.field.Zeros((self.dimension, len(self)))]
+            ).view(self.field)
         old_logicals_z = self.get_logical_ops(Pauli.Z, symplectic=True)
         basis_change = np.linalg.inv(math.symplectic_conjugate(old_logicals_z) @ logicals_ops_x.T)
         new_logicals_z = basis_change @ old_logicals_z
@@ -1538,8 +1548,19 @@ class QuditCode(AbstractCode):
 
         Plugging (1) into (2), we find ``M = (Kx @ Ω @ Lz.T)**-1``, and in turn plug M into (1)
         to get ``Lx = (Kx @ Ω @ Lz.T)**-1 @ Kx``.
+
+        The Z-type logical operators are given by a matrix with shape ``(k, 2*n)``.  As a
+        convenience, a matrix with shape ``(k, n)`` is also accepted, in which case its entries are
+        taken to be the Z-type support of Z-only logical operators (that is, with zero X-type
+        support).
         """
         logicals_ops_z = np.asanyarray(logicals_ops_z).view(self.field)
+        self._validate_logical_ops_shape(logicals_ops_z)
+        if logicals_ops_z.shape[1] == len(self):
+            # the given logical operators have only Z-type support
+            logicals_ops_z = np.hstack(
+                [self.field.Zeros((self.dimension, len(self))), logicals_ops_z]
+            ).view(self.field)
         old_logicals_x = self.get_logical_ops(Pauli.X, symplectic=True)
         basis_change = np.linalg.inv(old_logicals_x @ math.symplectic_conjugate(logicals_ops_z).T)
         new_logicals_x = basis_change @ old_logicals_x
@@ -2756,6 +2777,7 @@ class CSSCode(QuditCode):
         get ``Lz = (Kz @ Lx.T)**-1 @ Kz``.
         """
         logicals_ops_x = np.asanyarray(logicals_ops_x).view(self.field)
+        self._validate_logical_ops_shape(logicals_ops_x)
         old_logicals_z = self.get_logical_ops(Pauli.Z)
         new_logicals_z = np.linalg.inv(old_logicals_z @ logicals_ops_x.T) @ old_logicals_z
         return self.set_logical_ops_xz(
@@ -2784,6 +2806,7 @@ class CSSCode(QuditCode):
         get ``Lx = (Kx @ Lz.T)**-1 @ Kx``.
         """
         logicals_ops_z = np.asanyarray(logicals_ops_z).view(self.field)
+        self._validate_logical_ops_shape(logicals_ops_z)
         old_logicals_x = self.get_logical_ops(Pauli.X)
         new_logicals_x = np.linalg.inv(old_logicals_x @ logicals_ops_z.T) @ old_logicals_x
         return self.set_logical_ops_xz(
@@ -2984,8 +3007,8 @@ class CSSCode(QuditCode):
     def get_distance_bound(
         self,
         num_trials: int = 1,
-        *,
         pauli: PauliXZ | None = None,
+        *,
         cutoff: int | None = None,
         **bound_kwargs: Any,
     ) -> int | float:

--- a/src/qldpc/codes/common_test.py
+++ b/src/qldpc/codes/common_test.py
@@ -278,7 +278,9 @@ def get_random_qudit_code(qudits: int, checks: int, field: int = 2) -> codes.Qud
 def test_qubit_code(num_qubits: int = 5, num_checks: int = 3) -> None:
     """Random qubit code."""
     assert get_random_qudit_code(num_qubits, num_checks).num_qubits == num_qubits
-    with pytest.raises(ValueError, match="3-dimensional qudits"):
+    with pytest.raises(
+        ValueError, match=r"3-dimensional qudits\.\s+Try calling QuditCode\.num_qudits"
+    ):
         assert get_random_qudit_code(num_qubits, num_checks, field=3).num_qubits
 
 
@@ -406,8 +408,10 @@ def test_qudit_stabilizers(field: int, bits: int = 5, checks: int = 3) -> None:
     assert code_a == code_b
     assert strings == code_b.get_strings()
 
-    with pytest.raises(ValueError, match="different lengths"):
+    with pytest.raises(ValueError, match=r"different lengths \(1 and 2\)"):
         codes.QuditCode.from_strings(["I", "II"], field=field)
+    with pytest.raises(ValueError, match="empty collection"):
+        codes.QuditCode.from_strings([], field=field)
 
 
 def test_from_qecdb_id() -> None:
@@ -789,6 +793,10 @@ def test_css_ops(pytestconfig: pytest.Config) -> None:
 def test_distance_css() -> None:
     """Distance calculations for CSS codes."""
     code: codes.CSSCode
+
+    # a bare CSSCode has no specialized exact-distance method, so it falls back to brute force
+    bare_code = codes.QuditCode(codes.SteaneCode().matrix).to_css()
+    assert bare_code.get_distance_exact() == 3
 
     # qubit code distance
     code = codes.QuditCode(codes.SHPCode(codes.RepetitionCode(2)).matrix).to_css()

--- a/src/qldpc/codes/common_test.py
+++ b/src/qldpc/codes/common_test.py
@@ -562,6 +562,45 @@ def test_qudit_ops(pytestconfig: pytest.Config) -> None:
     assert np.array_equal(code.get_stabilizer_ops(canonicalized=True), stabilizer_ops[:-1])
 
 
+def test_set_logical_ops_single_type_support() -> None:
+    """QuditCode.set_logical_ops_x/z accept width-n single-type support."""
+    css_code = codes.SteaneCode()
+    matrix = css_code.matrix
+    num_qudits = len(css_code)
+
+    # a valid pure-X (pure-Z) logical basis in symplectic (k, 2n) form, and its width-n support
+    logical_x = css_code.get_logical_ops(Pauli.X, symplectic=True).view(css_code.field)
+    logical_z = css_code.get_logical_ops(Pauli.Z, symplectic=True).view(css_code.field)
+    assert not np.any(logical_x[:, num_qudits:])  # no Z-type support
+    assert not np.any(logical_z[:, :num_qudits])  # no X-type support
+
+    # setting the width-n support is equivalent to setting the full symplectic operators
+    code_full = codes.QuditCode(matrix)
+    code_full.set_logical_ops_x(logical_x)
+    code_half = codes.QuditCode(matrix)
+    code_half.set_logical_ops_x(logical_x[:, :num_qudits])
+    assert np.array_equal(code_full.get_logical_ops(), code_half.get_logical_ops())
+
+    code_full = codes.QuditCode(matrix)
+    code_full.set_logical_ops_z(logical_z)
+    code_half = codes.QuditCode(matrix)
+    code_half.set_logical_ops_z(logical_z[:, num_qudits:])
+    assert np.array_equal(code_full.get_logical_ops(), code_half.get_logical_ops())
+
+    # providing the wrong number of logical operators raises a helpful error, including for the
+    # CSSCode overrides and for 1-D inputs (which would otherwise raise a cryptic IndexError)
+    with pytest.raises(ValueError, match="Expected 1 logical operators"):
+        codes.QuditCode(matrix).set_logical_ops_x(logical_x[:0])
+    with pytest.raises(ValueError, match="Expected 1 logical operators"):
+        codes.QuditCode(matrix).set_logical_ops_z(np.vstack([logical_z, logical_z]))
+    with pytest.raises(ValueError, match="Expected 1 logical operators"):
+        codes.QuditCode(matrix).set_logical_ops_x(logical_x[0])  # 1-D input
+    with pytest.raises(ValueError, match="Expected 1 logical operators"):
+        codes.SteaneCode().set_logical_ops_x(css_code.get_logical_ops(Pauli.X)[:0])
+    with pytest.raises(ValueError, match="Expected 1 logical operators"):
+        codes.SteaneCode().set_logical_ops_z(css_code.get_logical_ops(Pauli.Z)[0])  # 1-D input
+
+
 def test_qudit_concatenation() -> None:
     """Concatenate qudit codes."""
     code_5q = codes.FiveQubitCode()
@@ -710,13 +749,6 @@ def test_css_code(pytestconfig: pytest.Config) -> None:
     subgraphs = code.get_syndrome_subgraphs()
     assert nx.utils.graphs_equal(subgraphs[0], code.get_graph(Pauli.X))
     assert nx.utils.graphs_equal(subgraphs[1], code.get_graph(Pauli.Z))
-
-    # invoking the QuditCode base get_logical_ops on a CSSCode instance defers to the CSSCode
-    # implementation, so it does not populate the shared cache with a different-format basis
-    expected_logicals_x = codes.SurfaceCode(3).get_logical_ops(Pauli.X, symplectic=True)
-    css_code = codes.SurfaceCode(3)  # a fresh instance with an empty logical-operator cache
-    codes.QuditCode.get_logical_ops(css_code, None)
-    assert np.array_equal(css_code.get_logical_ops(Pauli.X, symplectic=True), expected_logicals_x)
 
 
 def test_css_from_strings() -> None:

--- a/src/qldpc/codes/common_test.py
+++ b/src/qldpc/codes/common_test.py
@@ -324,9 +324,17 @@ def test_qudit_codes() -> None:
     with pytest.raises(ValueError, match="incorrect commutation relations"):
         two_codes.set_logical_ops(logical_ops, skip_validation=False)
 
-    # invalid modifications of logical operators break commutation relations
+    # making an X-type logical anticommute with another X-type logical is rejected; the X-Z
+    # cross-type commutation relations alone do not detect a broken intra-type relation
     logical_ops = two_codes.get_logical_ops().copy()
-    logical_ops[0, -1] += two_codes.field(1)
+    logical_ops[1] += logical_ops[two_codes.dimension]  # Lx[1] += Lz[0]
+    with pytest.raises(ValueError, match="incorrect commutation relations"):
+        two_codes.set_logical_ops(logical_ops, skip_validation=False)
+
+    # adding a destabilizer to a logical operator preserves the commutation relations among the
+    # logical operators but violates a parity check
+    logical_ops = two_codes.get_logical_ops().copy()
+    logical_ops[0] += two_codes.get_destabilizer_ops()[0]
     with pytest.raises(ValueError, match="violate parity checks"):
         two_codes.set_logical_ops(logical_ops, skip_validation=False)
 

--- a/src/qldpc/codes/common_test.py
+++ b/src/qldpc/codes/common_test.py
@@ -711,6 +711,13 @@ def test_css_code(pytestconfig: pytest.Config) -> None:
     assert nx.utils.graphs_equal(subgraphs[0], code.get_graph(Pauli.X))
     assert nx.utils.graphs_equal(subgraphs[1], code.get_graph(Pauli.Z))
 
+    # invoking the QuditCode base get_logical_ops on a CSSCode instance defers to the CSSCode
+    # implementation, so it does not populate the shared cache with a different-format basis
+    expected_logicals_x = codes.SurfaceCode(3).get_logical_ops(Pauli.X, symplectic=True)
+    css_code = codes.SurfaceCode(3)  # a fresh instance with an empty logical-operator cache
+    codes.QuditCode.get_logical_ops(css_code, None)
+    assert np.array_equal(css_code.get_logical_ops(Pauli.X, symplectic=True), expected_logicals_x)
+
 
 def test_css_from_strings() -> None:
     """Construct a CSSCode from parity check strings."""

--- a/src/qldpc/codes/common_test.py
+++ b/src/qldpc/codes/common_test.py
@@ -298,6 +298,12 @@ def test_qudit_codes() -> None:
     assert code.is_equiv_to(codes.QuditCode(code))
     assert_valid_subgraphs(code)
 
+    # parity checks whose support overlaps no other check still appear in the subgraphs, and a
+    # check with no support at all is simply omitted (it contributes no edges to the Tanner graph)
+    assert_valid_subgraphs(codes.QuditCode.from_strings(["Y Y I I", "I I Z Z"]))
+    assert_valid_subgraphs(codes.QuditCode.from_strings(["X X X"]))
+    assert_valid_subgraphs(codes.QuditCode.from_strings(["X X X", "I I I"]))
+
     # equivalence to code with redundant stabilizers
     redundant_code = codes.QuditCode(np.vstack([code.matrix, code.matrix]))
     assert code.is_equiv_to(redundant_code)
@@ -559,6 +565,12 @@ def test_qudit_concatenation() -> None:
     assert len(code) == 10 * len(code_5q)
     assert code.dimension == 2 * code_5q.dimension
 
+    # concatenation does not mutate the logical operators of the outer code passed by the caller
+    outer = codes.QuditCode.stack([code_5q] * len(code_5q))  # dimension == inner physical qudits
+    logical_ops_before = outer.get_logical_ops().copy()
+    codes.QuditCode.concatenate(outer, code_5q, [1, 0, 2, 3, 4])
+    assert np.array_equal(outer.get_logical_ops(), logical_ops_before)
+
     # cover some errors
     with pytest.raises(ValueError, match="different fields"):
         codes.QuditCode.concatenate(code_5q, codes.ToricCode(2, field=3))
@@ -566,7 +578,7 @@ def test_qudit_concatenation() -> None:
         codes.QuditCode.concatenate(code_5q, code_5q, [0, 1, 2])
 
 
-def test_quantum_capacity() -> None:
+def test_quantum_capacity(pytestconfig: pytest.Config) -> None:
     """Logical error rates in a code capacity model."""
     code = codes.FiveQubitCode()
 
@@ -584,6 +596,28 @@ def test_quantum_capacity() -> None:
     )
     assert logical_error_rate_func(0, discard_rate=True) == (0, 0)  # no errors at p=0
     assert logical_error_rate_func(0.5, discard_rate=True)[0] > 0  # all syndromes → erasure
+
+    # a subsystem code is decoded against its stabilizer generators rather than its more numerous,
+    # non-commuting gauge generators, so the QuditCode and CSSCode views of the same subsystem code
+    # decode identically and yield the same logical error rate
+    seed = pytestconfig.getoption("randomly_seed")
+    css_code = codes.BaconShorCode(3)
+    qudit_code = codes.QuditCode(css_code.matrix)
+    assert qudit_code.is_subsystem_code
+    np.random.seed(seed)
+    css_rate = css_code.get_logical_error_rate_func(num_samples=200, max_error_rate=0.3)(0.1)
+    np.random.seed(seed)
+    qudit_rate = qudit_code.get_logical_error_rate_func(num_samples=200, max_error_rate=0.3)(0.1)
+    assert np.allclose(qudit_rate, css_rate)
+
+    # a code over a non-binary field is decoded with a field-aware decoder: its syndrome matrix is
+    # a field array, from which the decoder is selected to match the field
+    qudit_code = codes.QuditCode(codes.BaconShorCode(3, field=3).matrix)
+    logical_error_rate_func = qudit_code.get_logical_error_rate_func(
+        num_samples=100, max_error_rate=0.2
+    )
+    assert logical_error_rate_func(0) == (0, 0)  # no logical error with zero uncertainty
+    assert logical_error_rate_func(0.1)[0] > 0  # nonzero logical error rate at a nonzero rate
 
 
 def test_qudit_to_css() -> None:
@@ -901,3 +935,13 @@ def test_css_capacity() -> None:
     )
     assert logical_error_rate_func_x(0, discard_rate=True) == (0, 0)  # no errors at p=0
     assert logical_error_rate_func_x(0.5, discard_rate=True)[0] > 0  # X syndromes → erasure
+
+    # a subsystem code is decoded against its stabilizer generators, whose number differs from the
+    # number of parity checks (gauge generators), so a syndrome has one entry per stabilizer
+    subsystem_code = codes.BaconShorCode(3)
+    assert subsystem_code.is_subsystem_code
+    logical_error_rate_func = subsystem_code.get_logical_error_rate_func(
+        num_samples=200, max_error_rate=0.3
+    )
+    assert logical_error_rate_func(0) == (0, 0)  # no logical error with zero uncertainty
+    assert logical_error_rate_func(0.1)[0] > 0  # nonzero logical error rate at a nonzero rate


### PR DESCRIPTION
### AI-generated summary

Correctness and robustness fixes in `codes/common.py`, plus extraction of the Monte-Carlo capacity helpers into a new `codes/_monte_carlo.py`. No public API signatures are added or removed; the behavioral changes are bug fixes and tightened/loosened input validation on existing methods.

## Capacity estimation

- Decode against stabilizer generators (not the gauge matrix), fixing a crash on subsystem codes and letting the decoder be selected correctly for codes over non-binary fields.
- Extract the Monte-Carlo helpers (`ErrorRateFunc`, sample allocation, error-weight probabilities, decode-and-erasure) into `codes/_monte_carlo.py`, re-exported from `codes`, with dedicated unit tests; rename the per-weight sampler to reflect that it returns failure and discard counts.
- `ErrorRateFunc`: at `error_rate == 1` place the probability mass at `block_length` only when it is in range (no out-of-bounds slice or impossible weights), and share one zero-sample divisor guard across the infidelity and discard-rate paths.

## Logical operators

- `set_logical_ops`: validate the full symplectic Gram matrix, so a basis with anticommuting same-type logicals is rejected rather than silently accepted.
- `set_logical_ops_x` / `set_logical_ops_z`: accept a width-`n` single-type matrix as a convenience alongside the full width-`2n` symplectic form, and validate the operator count and shape up front, so a wrong number of operators (or a 1-D array) raises a clear error instead of a cryptic linear-algebra or indexing failure. The check is shared by the `QuditCode` and `CSSCode` implementations.
- Transversal-circuit logical corrections: look up logical operators through the code's own `get_logical_ops`, so CSS and non-CSS codes read the shared logical-operator cache in a consistent format.

## Other

- `from_strings`: reject an empty collection of parity checks with a clear error instead of an `IndexError`, and report the mismatched lengths when checks differ.
- `_get_distance_exact`: cover a reachable fallback with a bare-`CSSCode` distance test.
- Assorted naming and docstring cleanups.