### PR TITLE
Fix local Fourier transforms (conjugated) over non-binary fields

### DIFF
--- a/src/qldpc/codes/common.py
+++ b/src/qldpc/codes/common.py
@@ -1887,10 +1887,11 @@ class QuditCode(AbstractCode):
             qudits = range(len(self))
 
         def transform_ops(ops: galois.FieldArray) -> galois.FieldArray:
-            """Fourier-transform the given Pauli strings."""
-            ops_reshaped = ops.copy().reshape(-1, 2, len(self))
-            ops_reshaped[:, :, qudits] = ops_reshaped[:, ::-1, qudits]
-            return ops_reshaped.reshape(-1, 2 * len(self)).view(self.field)
+            """Fourier-transform the given Pauli strings on the chosen qudits."""
+            result = ops.copy().reshape(-1, 2, len(self))
+            conjugated = math.symplectic_conjugate(ops).reshape(-1, 2, len(self))
+            result[:, :, qudits] = conjugated[:, :, qudits]
+            return result.reshape(-1, 2 * len(self)).view(self.field)
 
         # transform the parity check matrix, and any other operators that are already known
         code = QuditCode(transform_ops(self.matrix), is_subsystem_code=self._is_subsystem_code)

--- a/src/qldpc/codes/common_test.py
+++ b/src/qldpc/codes/common_test.py
@@ -463,6 +463,23 @@ def test_qudit_deformations() -> None:
     assert code.is_equiv_to(code.deformed("H 0 1 2 3 4 5 6", preserve_logicals=True))
 
 
+def test_conjugated_over_qudits() -> None:
+    """conjugated() is a symplectic map, so it preserves code structure over every field."""
+    conj = math.symplectic_conjugate
+    for base in [codes.BaconShorCode(3, field=3), codes.ToricCode(4, field=4)]:
+        code = codes.QuditCode(base.matrix)
+        code.get_logical_ops()  # populate the cache so conjugated() transforms it too
+        conjugated = code.conjugated([0, 5, 7])
+        # the transform preserves every symplectic product, so the parity checks keep their
+        # commutation relations and the code stays the same size
+        assert np.array_equal(
+            code.matrix @ conj(code.matrix).T, conjugated.matrix @ conj(conjugated.matrix).T
+        )
+        assert codes.QuditCode(conjugated.matrix).dimension == code.dimension
+        # the transformed logical operators are still a valid symplectic basis for the new code
+        conjugated.set_logical_ops(conjugated.get_logical_ops())
+
+
 def get_codes_for_testing_ops() -> Iterator[codes.CSSCode]:
     """Iterate over some codes for testing operator constructions."""
     # Bacon-Shor code and toric codes


### PR DESCRIPTION
### AI-assisted summary

`QuditCode.conjugated()` previously transformed the chosen qudits by swapping their X-type and Z-type components.  That swap is symplectic only over GF(2); over a field of odd characteristic it drops a sign and flips the commutation relations of the conjugated qudits.  `QuditCode.conjugated()` now applies the local Fourier map (x, z) -> (z, -x) through `math.symplectic_conjugate`, restricted to the chosen qudits, so the conjugation convention lives in one place.

A regression test checks that conjugating a code over GF(3) and GF(4) preserves its commutation relations, dimension, and logical operator basis.